### PR TITLE
[FEAT] 피드, 좋아요 엔티티 구현

### DIFF
--- a/src/main/java/kakao/rebit/Likes/entity/Likes.java
+++ b/src/main/java/kakao/rebit/Likes/entity/Likes.java
@@ -27,6 +27,10 @@ public class Likes {
     @JoinColumn(name = "feed_id")
     private Feed feed;
 
+    protected Likes() {
+
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/kakao/rebit/Likes/entity/Likes.java
+++ b/src/main/java/kakao/rebit/Likes/entity/Likes.java
@@ -1,0 +1,41 @@
+package kakao.rebit.Likes.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import kakao.rebit.feed.entity.Feed;
+import kakao.rebit.member.entity.Member;
+
+@Entity
+@Table(name = "likes")
+public class Likes {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_id")
+    private Feed feed;
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public Feed getFeed() {
+        return feed;
+    }
+}

--- a/src/main/java/kakao/rebit/Likes/entity/Likes.java
+++ b/src/main/java/kakao/rebit/Likes/entity/Likes.java
@@ -31,6 +31,11 @@ public class Likes {
 
     }
 
+    public Likes(Member member, Feed feed) {
+        this.member = member;
+        this.feed = feed;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/kakao/rebit/Likes/entity/Likes.java
+++ b/src/main/java/kakao/rebit/Likes/entity/Likes.java
@@ -6,7 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kakao.rebit.feed.entity.Feed;
 import kakao.rebit.member.entity.Member;
@@ -19,11 +19,11 @@ public class Likes {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id")
     private Feed feed;
 

--- a/src/main/java/kakao/rebit/Likes/repository/LikesRepository.java
+++ b/src/main/java/kakao/rebit/Likes/repository/LikesRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LikesRepository extends JpaRepository<Likes, Long> {
+
 }

--- a/src/main/java/kakao/rebit/Likes/repository/LikesRepository.java
+++ b/src/main/java/kakao/rebit/Likes/repository/LikesRepository.java
@@ -1,0 +1,9 @@
+package kakao.rebit.Likes.repository;
+
+import kakao.rebit.Likes.entity.Likes;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikesRepository extends JpaRepository<Likes, Long> {
+}

--- a/src/main/java/kakao/rebit/feed/entity/FavoriteBook.java
+++ b/src/main/java/kakao/rebit/feed/entity/FavoriteBook.java
@@ -1,0 +1,30 @@
+package kakao.rebit.feed.entity;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import kakao.rebit.member.entity.Member;
+
+@Entity
+@DiscriminatorValue("FB")
+public class FavoriteBook extends Feed{
+    private String brief_review;
+
+    private String full_review;
+
+    protected FavoriteBook(){
+    }
+
+    public FavoriteBook(Long id, Member member, int likes, Book book, String brief_review, String full_review) {
+        super(id, member, likes, book);
+        this.brief_review = brief_review;
+        this.full_review = full_review;
+    }
+
+    public String getBrief_review() {
+        return brief_review;
+    }
+
+    public String getFull_review() {
+        return full_review;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/entity/FavoriteBook.java
+++ b/src/main/java/kakao/rebit/feed/entity/FavoriteBook.java
@@ -6,16 +6,18 @@ import kakao.rebit.member.entity.Member;
 
 @Entity
 @DiscriminatorValue("FB")
-public class FavoriteBook extends Feed{
+public class FavoriteBook extends Feed {
+
     private String brief_review;
 
     private String full_review;
 
-    protected FavoriteBook(){
+    protected FavoriteBook() {
     }
 
-    public FavoriteBook(Long id, Member member, int likes, Book book, String brief_review, String full_review) {
-        super(id, member, likes, book);
+    public FavoriteBook(Member member, int likes, Book book, String brief_review,
+            String full_review) {
+        super(member, likes, book);
         this.brief_review = brief_review;
         this.full_review = full_review;
     }

--- a/src/main/java/kakao/rebit/feed/entity/FavoriteBook.java
+++ b/src/main/java/kakao/rebit/feed/entity/FavoriteBook.java
@@ -15,9 +15,9 @@ public class FavoriteBook extends Feed {
     protected FavoriteBook() {
     }
 
-    public FavoriteBook(Member member, int likes, Book book, String brief_review,
+    public FavoriteBook(Member member, Book book, String brief_review,
             String full_review) {
-        super(member, likes, book);
+        super(member, book);
         this.brief_review = brief_review;
         this.full_review = full_review;
     }

--- a/src/main/java/kakao/rebit/feed/entity/Feed.java
+++ b/src/main/java/kakao/rebit/feed/entity/Feed.java
@@ -30,6 +30,10 @@ public abstract class Feed extends BaseEntity {
 
     private int likes;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "isbn")
+    private Book book;
+
     protected Feed() {
     }
 
@@ -38,11 +42,6 @@ public abstract class Feed extends BaseEntity {
         this.likes = likes;
         this.book = book;
     }
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "isbn")
-    private Book book;
-
 
     public Long getId() {
         return id;

--- a/src/main/java/kakao/rebit/feed/entity/Feed.java
+++ b/src/main/java/kakao/rebit/feed/entity/Feed.java
@@ -1,5 +1,6 @@
 package kakao.rebit.feed.entity;
 
+import jakarta.persistence.Basic;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -13,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kakao.rebit.common.persistence.BaseEntity;
 import kakao.rebit.member.entity.Member;
+import org.hibernate.annotations.Formula;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -28,6 +30,8 @@ public abstract class Feed extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Basic(fetch = FetchType.LAZY)
+    @Formula("(SELECT COUNT(1) FROM likes l WHERE l.feed_id = id)")
     private int likes;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -37,9 +41,8 @@ public abstract class Feed extends BaseEntity {
     protected Feed() {
     }
 
-    protected Feed(Member member, int likes, Book book) {
+    protected Feed(Member member, Book book) {
         this.member = member;
-        this.likes = likes;
         this.book = book;
     }
 

--- a/src/main/java/kakao/rebit/feed/entity/Feed.java
+++ b/src/main/java/kakao/rebit/feed/entity/Feed.java
@@ -16,7 +16,7 @@ import kakao.rebit.member.entity.Member;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn(name="type")
+@DiscriminatorColumn(name = "type")
 @Table(name = "feed")
 public abstract class Feed extends BaseEntity {
 
@@ -30,11 +30,10 @@ public abstract class Feed extends BaseEntity {
 
     private int likes;
 
-    protected  Feed(){
+    protected Feed() {
     }
 
-    protected Feed(Long id, Member member, int likes, Book book) {
-        this.id = id;
+    protected Feed(Member member, int likes, Book book) {
         this.member = member;
         this.likes = likes;
         this.book = book;

--- a/src/main/java/kakao/rebit/feed/entity/Feed.java
+++ b/src/main/java/kakao/rebit/feed/entity/Feed.java
@@ -1,0 +1,63 @@
+package kakao.rebit.feed.entity;
+
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import kakao.rebit.common.persistence.BaseEntity;
+import kakao.rebit.member.entity.Member;
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name="type")
+@Table(name = "feed")
+public abstract class Feed extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private int likes;
+
+    protected  Feed(){
+    }
+
+    protected Feed(Long id, Member member, int likes, Book book) {
+        this.id = id;
+        this.member = member;
+        this.likes = likes;
+        this.book = book;
+    }
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "isbn")
+    private Book book;
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public int getLikes() {
+        return likes;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/entity/Magazine.java
+++ b/src/main/java/kakao/rebit/feed/entity/Magazine.java
@@ -1,0 +1,40 @@
+package kakao.rebit.feed.entity;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import kakao.rebit.member.entity.Member;
+
+@Entity
+@Table(name = "magazine")
+@DiscriminatorValue("M")
+public class Magazine extends Feed {
+
+    private String name;
+    private String imageUrl;
+    private String content;
+
+    protected Magazine() {
+
+    }
+
+    public Magazine(Member member, int likes, Book book, String name, String imageUrl,
+            String content) {
+        super(member, likes, book);
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.content = content;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/entity/Magazine.java
+++ b/src/main/java/kakao/rebit/feed/entity/Magazine.java
@@ -18,9 +18,9 @@ public class Magazine extends Feed {
 
     }
 
-    public Magazine(Member member, int likes, Book book, String name, String imageUrl,
+    public Magazine(Member member, Book book, String name, String imageUrl,
             String content) {
-        super(member, likes, book);
+        super(member, book);
         this.name = name;
         this.imageUrl = imageUrl;
         this.content = content;

--- a/src/main/java/kakao/rebit/feed/entity/Story.java
+++ b/src/main/java/kakao/rebit/feed/entity/Story.java
@@ -1,0 +1,30 @@
+package kakao.rebit.feed.entity;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import kakao.rebit.member.entity.Member;
+
+@Entity
+@DiscriminatorValue("FB")
+public class Story extends Feed{
+    private String imageUrl;
+
+    private String content;
+
+    protected Story(){
+    }
+
+    public Story(Long id, Member member, int likes, Book book, String imageUrl, String content) {
+        super(id, member, likes, book);
+        this.imageUrl = imageUrl;
+        this.content = content;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/entity/Story.java
+++ b/src/main/java/kakao/rebit/feed/entity/Story.java
@@ -5,7 +5,7 @@ import jakarta.persistence.Entity;
 import kakao.rebit.member.entity.Member;
 
 @Entity
-@DiscriminatorValue("FB")
+@DiscriminatorValue("S")
 public class Story extends Feed {
 
     private String imageUrl;

--- a/src/main/java/kakao/rebit/feed/entity/Story.java
+++ b/src/main/java/kakao/rebit/feed/entity/Story.java
@@ -15,8 +15,8 @@ public class Story extends Feed {
     protected Story() {
     }
 
-    public Story(Member member, int likes, Book book, String imageUrl, String content) {
-        super(member, likes, book);
+    public Story(Member member, Book book, String imageUrl, String content) {
+        super(member, book);
         this.imageUrl = imageUrl;
         this.content = content;
     }

--- a/src/main/java/kakao/rebit/feed/entity/Story.java
+++ b/src/main/java/kakao/rebit/feed/entity/Story.java
@@ -6,16 +6,17 @@ import kakao.rebit.member.entity.Member;
 
 @Entity
 @DiscriminatorValue("FB")
-public class Story extends Feed{
+public class Story extends Feed {
+
     private String imageUrl;
 
     private String content;
 
-    protected Story(){
+    protected Story() {
     }
 
-    public Story(Long id, Member member, int likes, Book book, String imageUrl, String content) {
-        super(id, member, likes, book);
+    public Story(Member member, int likes, Book book, String imageUrl, String content) {
+        super(member, likes, book);
         this.imageUrl = imageUrl;
         this.content = content;
     }

--- a/src/main/java/kakao/rebit/feed/repository/FavoriteBookRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/FavoriteBookRepository.java
@@ -1,0 +1,10 @@
+package kakao.rebit.feed.repository;
+
+import kakao.rebit.feed.entity.FavoriteBook;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FavoriteBookRepository extends JpaRepository<FavoriteBook, Long> {
+
+}

--- a/src/main/java/kakao/rebit/feed/repository/FeedRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/FeedRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedRepository extends JpaRepository<Feed, Long> {
+
 }

--- a/src/main/java/kakao/rebit/feed/repository/FeedRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/FeedRepository.java
@@ -1,6 +1,5 @@
 package kakao.rebit.feed.repository;
 
-import java.util.List;
 import kakao.rebit.feed.entity.Feed;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/kakao/rebit/feed/repository/FeedRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/FeedRepository.java
@@ -1,0 +1,10 @@
+package kakao.rebit.feed.repository;
+
+import java.util.List;
+import kakao.rebit.feed.entity.Feed;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+}

--- a/src/main/java/kakao/rebit/feed/repository/MagazineRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/MagazineRepository.java
@@ -1,0 +1,8 @@
+package kakao.rebit.feed.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MagazineRepository {
+
+}

--- a/src/main/java/kakao/rebit/feed/repository/StoryRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/StoryRepository.java
@@ -1,0 +1,10 @@
+package kakao.rebit.feed.repository;
+
+import kakao.rebit.feed.entity.Story;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoryRepository extends JpaRepository<Story, Long> {
+
+}


### PR DESCRIPTION
## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용 및 변경 사항
- Feed, FavoriteBook, Story 엔티티 구현
- 상속관계 매핑: Feed 부모, FavoriteBook과 Story를 자식으로 JOIN 전략 사용
- Feed, FavoriteBook, Story 레파지터리 구현
- Likes 엔티티 구현
- Likes 레파지터리 구현

## 이슈 링크
close #3 

## 참고사항
Feed 엔티티의 Likes 필드가 피드,좋아요의 개수를 나타내는 건데, 추후에 Service 로직에서 좋아요 추가, 삭제 할 때 갱신 되도록 구현하겠습니다. 지금은 그냥 생성자를 통해 받을 수 있게 했습니다.
