### PR TITLE
[FEAT] 책, 독서일기 엔티티 구현

### DIFF
--- a/src/main/java/kakao/rebit/book/entity/Book.java
+++ b/src/main/java/kakao/rebit/book/entity/Book.java
@@ -22,7 +22,6 @@ public class Book extends BaseEntity {
 
     private String publisher;
 
-    @Column(name = "image_url")
     private String imageUrl;
 
     protected Book() {

--- a/src/main/java/kakao/rebit/book/entity/Book.java
+++ b/src/main/java/kakao/rebit/book/entity/Book.java
@@ -1,0 +1,51 @@
+package kakao.rebit.book.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kakao.rebit.common.persistence.BaseEntity;
+
+@Entity
+@Table(name = "book")
+public class Book extends BaseEntity {
+
+    @Id
+    private String isbn;
+
+    private String title;
+
+    @Column(length = 500)
+    private String description;
+
+    private String author;
+
+    private String publisher;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    protected Book() {
+    }
+
+    public Book(String isbn, String title, String description, String author, String publisher, String imageUrl) {
+        this.isbn = isbn;
+        this.title = title;
+        this.description = description;
+        this.author = author;
+        this.publisher = publisher;
+        this.imageUrl = imageUrl;
+    }
+
+    public String getIsbn() { return isbn; }
+
+    public String getTitle() { return title; }
+
+    public String getDescription() { return description; }
+
+    public String getAuthor() { return author; }
+
+    public String getPublisher() { return publisher; }
+
+    public String getImageUrl() { return imageUrl; }
+}

--- a/src/main/java/kakao/rebit/book/entity/Book.java
+++ b/src/main/java/kakao/rebit/book/entity/Book.java
@@ -36,15 +36,27 @@ public class Book extends BaseEntity {
         this.imageUrl = imageUrl;
     }
 
-    public String getIsbn() { return isbn; }
+    public String getIsbn() {
+        return isbn;
+    }
 
-    public String getTitle() { return title; }
+    public String getTitle() {
+        return title;
+    }
 
-    public String getDescription() { return description; }
+    public String getDescription() {
+        return description;
+    }
 
-    public String getAuthor() { return author; }
+    public String getAuthor() {
+        return author;
+    }
 
-    public String getPublisher() { return publisher; }
+    public String getPublisher() {
+        return publisher;
+    }
 
-    public String getImageUrl() { return imageUrl; }
+    public String getImageUrl() {
+        return imageUrl;
+    }
 }

--- a/src/main/java/kakao/rebit/book/repository/BookRepository.java
+++ b/src/main/java/kakao/rebit/book/repository/BookRepository.java
@@ -1,0 +1,7 @@
+package kakao.rebit.book.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import kakao.rebit.book.entity.Book;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/src/main/java/kakao/rebit/book/repository/BookRepository.java
+++ b/src/main/java/kakao/rebit/book/repository/BookRepository.java
@@ -1,7 +1,7 @@
 package kakao.rebit.book.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import kakao.rebit.book.entity.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
 }

--- a/src/main/java/kakao/rebit/diary/entity/Diary.java
+++ b/src/main/java/kakao/rebit/diary/entity/Diary.java
@@ -45,13 +45,7 @@ public class Diary extends BaseEntity {
 
     public String getContent() { return content; }
 
-    public void setContent(String content) { this.content = content; }
-
     public Member getMember() { return member; }
 
-    public void setMember(Member member) { this.member = member; }
-
     public Book getBook() { return book; }
-
-    public void setBook(Book book) { this.book = book; }
 }

--- a/src/main/java/kakao/rebit/diary/entity/Diary.java
+++ b/src/main/java/kakao/rebit/diary/entity/Diary.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import kakao.rebit.book.entity.Book;
 import kakao.rebit.common.persistence.BaseEntity;
 import kakao.rebit.member.entity.Member;
 
@@ -26,6 +27,10 @@ public class Diary extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "isbn")
+    private Book book;
 
     protected Diary() {
     }

--- a/src/main/java/kakao/rebit/diary/entity/Diary.java
+++ b/src/main/java/kakao/rebit/diary/entity/Diary.java
@@ -35,9 +35,10 @@ public class Diary extends BaseEntity {
     protected Diary() {
     }
 
-    public Diary(String content, Member member) {
+    public Diary(String content, Member member, Book book) {
         this.content = content;
         this.member = member;
+        this.book = book;
     }
 
     public Long getId() { return id; }

--- a/src/main/java/kakao/rebit/diary/entity/Diary.java
+++ b/src/main/java/kakao/rebit/diary/entity/Diary.java
@@ -1,0 +1,47 @@
+package kakao.rebit.diary.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import kakao.rebit.common.persistence.BaseEntity;
+import kakao.rebit.member.entity.Member;
+
+@Entity
+@Table(name = "diary")
+public class Diary extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 1000)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    protected Diary() {
+    }
+
+    public Diary(String content, Member member) {
+        this.content = content;
+        this.member = member;
+    }
+
+    public Long getId() { return id; }
+
+    public String getContent() { return content; }
+
+    public void setContent(String content) { this.content = content; }
+
+    public Member getMember() { return member; }
+
+    public void setMember(Member member) { this.member = member; }
+}

--- a/src/main/java/kakao/rebit/diary/entity/Diary.java
+++ b/src/main/java/kakao/rebit/diary/entity/Diary.java
@@ -50,4 +50,8 @@ public class Diary extends BaseEntity {
     public Member getMember() { return member; }
 
     public void setMember(Member member) { this.member = member; }
+
+    public Book getBook() { return book; }
+
+    public void setBook(Book book) { this.book = book; }
 }

--- a/src/main/java/kakao/rebit/diary/entity/Diary.java
+++ b/src/main/java/kakao/rebit/diary/entity/Diary.java
@@ -41,11 +41,19 @@ public class Diary extends BaseEntity {
         this.book = book;
     }
 
-    public Long getId() { return id; }
+    public Long getId() {
+        return id;
+    }
 
-    public String getContent() { return content; }
+    public String getContent() {
+        return content;
+    }
 
-    public Member getMember() { return member; }
+    public Member getMember() {
+        return member;
+    }
 
-    public Book getBook() { return book; }
+    public Book getBook() {
+        return book;
+    }
 }

--- a/src/main/java/kakao/rebit/diary/repository/DiaryRepository.java
+++ b/src/main/java/kakao/rebit/diary/repository/DiaryRepository.java
@@ -1,0 +1,7 @@
+package kakao.rebit.diary.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import kakao.rebit.diary.entity.Diary;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+}

--- a/src/main/java/kakao/rebit/diary/repository/DiaryRepository.java
+++ b/src/main/java/kakao/rebit/diary/repository/DiaryRepository.java
@@ -1,7 +1,7 @@
 package kakao.rebit.diary.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import kakao.rebit.diary.entity.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 }


### PR DESCRIPTION
## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용 및 변경 사항
- `Book` 엔티티 구현
- `BookRepository` 구현
- `Diary` 엔티티 구현:
  - `Member`와 `Book` 엔티티와의 다대일 관계 매핑 (연관관계 설정)
- `DiaryRepository` 구현

## 이슈 링크
close #5 
