### PR TITLE
[REFACTOR] 챌린지 인증글 엔티티에 작성자 정보 포함 하도록 수정

### DIFF
--- a/src/main/java/kakao/rebit/challenge/entity/ChallengeCertification.java
+++ b/src/main/java/kakao/rebit/challenge/entity/ChallengeCertification.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kakao.rebit.common.persistence.BaseEntity;
+import kakao.rebit.member.entity.Member;
 
 @Entity
 @Table(name = "challenge_certification")
@@ -28,14 +29,20 @@ public class ChallengeCertification extends BaseEntity {
     @JoinColumn(name = "challenge_id")
     private Challenge challenge;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
     protected ChallengeCertification() {
     }
 
-    public ChallengeCertification(String title, String imageUrl, String content, Challenge challenge) {
+    public ChallengeCertification(String title, String imageUrl, String content,
+        Challenge challenge, Member member) {
         this.title = title;
         this.imageUrl = imageUrl;
         this.content = content;
         this.challenge = challenge;
+        this.member = member;
     }
 
     public Long getId() {
@@ -56,5 +63,9 @@ public class ChallengeCertification extends BaseEntity {
 
     public Challenge getChallenge() {
         return challenge;
+    }
+
+    public Member getMember() {
+        return member;
     }
 }

--- a/src/main/java/kakao/rebit/wishlist/entity/BookWishlist.java
+++ b/src/main/java/kakao/rebit/wishlist/entity/BookWishlist.java
@@ -11,7 +11,7 @@ import kakao.rebit.member.entity.Member;
 
 @Entity
 @DiscriminatorValue("BOOK")
-@Table(name = "book_wishes")
+@Table(name = "book_wishlist")
 public class BookWishlist extends Wishlist {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/kakao/rebit/wishlist/entity/ChallengeWishlist.java
+++ b/src/main/java/kakao/rebit/wishlist/entity/ChallengeWishlist.java
@@ -11,7 +11,7 @@ import kakao.rebit.member.entity.Member;
 
 @Entity
 @DiscriminatorValue("CHALLENGE")
-@Table(name = "challenge_wishes")
+@Table(name = "challenge_wishlist")
 public class ChallengeWishlist extends Wishlist {
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## PR 유형
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용 및 변경 사항
- 챌린지 인증글 엔티티에 `작성자 정보`를 포함, 사용자(`member`) 테이블과 연관관계 매핑

  - 변경 사항 

    -  챌린지 인증글에 작성자필드 누락으로 인한 리팩토링

## 이슈 링크
close #14

## 참고사항
기존 PR삭제하고 Weekly-4 브랜치 판 뒤 다시 pr 날립니다. 
추가로, 멘토님께서 말씀하신 `책 위시리스트`와 `챌린지 위시리스트` 에서  `wishes` -> `wishlist` 로 
수정 하여 반영하였습니다. 