### PR TITLE
[FEAT] 챌린지 조회, 생성, 삭제 구현

### DIFF
--- a/src/main/java/kakao/rebit/challenge/controller/ChallengeController.java
+++ b/src/main/java/kakao/rebit/challenge/controller/ChallengeController.java
@@ -1,0 +1,52 @@
+package kakao.rebit.challenge.controller;
+
+import java.net.URI;
+import kakao.rebit.challenge.dto.ChallengeRequest;
+import kakao.rebit.challenge.dto.ChallengeResponse;
+import kakao.rebit.challenge.service.ChallengeService;
+import kakao.rebit.member.dto.MemberResponse;
+import kakao.rebit.member.entity.Role;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/challenges")
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    public ChallengeController(ChallengeService challengeService) {
+        this.challengeService = challengeService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<ChallengeResponse>> getChallenges(
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok().body(challengeService.getChallenges(pageable));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createChallenge(@RequestBody ChallengeRequest challengeRequest) {
+        // 소셜 로그인이 아직 구현되지 않아 임의의 빈 MemberResponse를 넣어줌
+        // 추후에 소셜 로그인 구현 후 ArgumentResolver로 MemberResponse를 받아오도록 수정
+        MemberResponse memberResponse = new MemberResponse(1L, "testUser", "imageUrl", "bio", Role.ROLE_USER, 10000);
+        Long challengeId = challengeService.createChallenge(memberResponse, challengeRequest);
+        return ResponseEntity.created(URI.create("/challenges/" + challengeId)).build();
+    }
+
+    @DeleteMapping("/{challengeId}")
+    public ResponseEntity<Void> deleteChallenge(@PathVariable("challengeId") Long challengeId) {
+        challengeService.deleteChallengeById(challengeId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/kakao/rebit/challenge/controller/ChallengeController.java
+++ b/src/main/java/kakao/rebit/challenge/controller/ChallengeController.java
@@ -35,6 +35,11 @@ public class ChallengeController {
         return ResponseEntity.ok().body(challengeService.getChallenges(pageable));
     }
 
+    @GetMapping("/{challenge-id}")
+    public ResponseEntity<ChallengeResponse> getChallenge(@PathVariable("challenge-id") Long challengeId) {
+        return ResponseEntity.ok().body(challengeService.getChallengeById(challengeId));
+    }
+
     @PostMapping
     public ResponseEntity<Void> createChallenge(@RequestBody ChallengeRequest challengeRequest) {
         // 소셜 로그인이 아직 구현되지 않아 임의의 빈 MemberResponse를 넣어줌
@@ -44,8 +49,8 @@ public class ChallengeController {
         return ResponseEntity.created(URI.create("/challenges/" + challengeId)).build();
     }
 
-    @DeleteMapping("/{challengeId}")
-    public ResponseEntity<Void> deleteChallenge(@PathVariable("challengeId") Long challengeId) {
+    @DeleteMapping("/{challenge-id}")
+    public ResponseEntity<Void> deleteChallenge(@PathVariable("challenge-id") Long challengeId) {
         challengeService.deleteChallengeById(challengeId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/kakao/rebit/challenge/dto/ChallengeRequest.java
+++ b/src/main/java/kakao/rebit/challenge/dto/ChallengeRequest.java
@@ -1,0 +1,20 @@
+package kakao.rebit.challenge.dto;
+
+import java.time.LocalDateTime;
+import kakao.rebit.challenge.entity.ChallengeType;
+
+public record ChallengeRequest(
+        String title,
+        String content,
+        String imageUrl,
+        ChallengeType type,
+        Integer minimumEntryFee,
+        LocalDateTime recruitmentStartDate,
+        LocalDateTime recruitmentEndDate,
+        LocalDateTime challengeStartDate,
+        LocalDateTime challengeEndDate,
+        Integer minHeadcount,
+        Integer maxHeadcount
+) {
+
+}

--- a/src/main/java/kakao/rebit/challenge/dto/ChallengeResponse.java
+++ b/src/main/java/kakao/rebit/challenge/dto/ChallengeResponse.java
@@ -1,0 +1,23 @@
+package kakao.rebit.challenge.dto;
+
+import java.time.LocalDateTime;
+import kakao.rebit.challenge.entity.ChallengeType;
+
+public record ChallengeResponse(
+        Long id,
+        CreatorResponse creator,
+        String title,
+        String content,
+        String imageUrl,
+        ChallengeType type,
+        Integer minimumEntryFee,
+        LocalDateTime recruitmentStartDate,
+        LocalDateTime recruitmentEndDate,
+        LocalDateTime challengeStartDate,
+        LocalDateTime challengeEndDate,
+        Integer minHeadcount,
+        Integer maxHeadcount,
+        LocalDateTime createdAt
+) {
+
+}

--- a/src/main/java/kakao/rebit/challenge/dto/CreatorResponse.java
+++ b/src/main/java/kakao/rebit/challenge/dto/CreatorResponse.java
@@ -1,0 +1,9 @@
+package kakao.rebit.challenge.dto;
+
+public record CreatorResponse(
+        Long id,
+        String nickname,
+        String imageUrl
+) {
+
+}

--- a/src/main/java/kakao/rebit/challenge/service/ChallengeService.java
+++ b/src/main/java/kakao/rebit/challenge/service/ChallengeService.java
@@ -1,0 +1,87 @@
+package kakao.rebit.challenge.service;
+
+import kakao.rebit.challenge.dto.ChallengeRequest;
+import kakao.rebit.challenge.dto.ChallengeResponse;
+import kakao.rebit.challenge.dto.CreatorResponse;
+import kakao.rebit.challenge.entity.Challenge;
+import kakao.rebit.challenge.entity.HeadcountLimit;
+import kakao.rebit.challenge.entity.Period;
+import kakao.rebit.challenge.repository.ChallengeRepository;
+import kakao.rebit.member.dto.MemberResponse;
+import kakao.rebit.member.entity.Member;
+import kakao.rebit.member.service.MemberService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ChallengeService {
+
+    private final ChallengeRepository challengeRepository;
+    private final MemberService memberService;
+
+    public ChallengeService(ChallengeRepository challengeRepository, MemberService memberService) {
+        this.challengeRepository = challengeRepository;
+        this.memberService = memberService;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ChallengeResponse> getChallenges(Pageable pageable) {
+        Page<Challenge> challenges = challengeRepository.findAll(pageable);
+        return challenges.map(this::toChallengeResponse);
+    }
+
+    @Transactional
+    public Long createChallenge(MemberResponse memberResponse, ChallengeRequest challengeRequest) {
+        Member member = memberService.findMemberByIdOrThrow(memberResponse.id());
+        Challenge challenge = toChallenge(member, challengeRequest);
+        return challengeRepository.save(challenge).getId();
+    }
+
+    @Transactional
+    public void deleteChallengeById(Long challengeId) {
+        challengeRepository.deleteById(challengeId);
+    }
+
+    private ChallengeResponse toChallengeResponse(Challenge challenge) {
+        return new ChallengeResponse(
+                challenge.getId(),
+                toCreatorResponse(challenge.getMember()),
+                challenge.getTitle(),
+                challenge.getContent(),
+                challenge.getImageUrl(),
+                challenge.getType(),
+                challenge.getMinimumEntryFee(),
+                challenge.getRecruitmentPeriod().getStartDate(),
+                challenge.getRecruitmentPeriod().getEndDate(),
+                challenge.getChallengePeriod().getStartDate(),
+                challenge.getChallengePeriod().getEndDate(),
+                challenge.getHeadcountLimit().getMinHeadcount(),
+                challenge.getHeadcountLimit().getMaxHeadcount(),
+                challenge.getCreatedAt()
+        );
+    }
+
+    private Challenge toChallenge(Member member, ChallengeRequest challengeRequest) {
+        return new Challenge(
+                member,
+                challengeRequest.title(),
+                challengeRequest.content(),
+                challengeRequest.imageUrl(),
+                challengeRequest.type(),
+                challengeRequest.minimumEntryFee(),
+                new Period(challengeRequest.recruitmentStartDate(), challengeRequest.recruitmentEndDate()),
+                new Period(challengeRequest.challengeStartDate(), challengeRequest.challengeEndDate()),
+                new HeadcountLimit(challengeRequest.minHeadcount(), challengeRequest.maxHeadcount())
+        );
+    }
+
+    private CreatorResponse toCreatorResponse(Member member) {
+        return new CreatorResponse(
+                member.getId(),
+                member.getNickname(),
+                member.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/kakao/rebit/challenge/service/ChallengeService.java
+++ b/src/main/java/kakao/rebit/challenge/service/ChallengeService.java
@@ -32,6 +32,17 @@ public class ChallengeService {
         return challenges.map(this::toChallengeResponse);
     }
 
+    @Transactional(readOnly = true)
+    public ChallengeResponse getChallengeById(Long challengeId) {
+        Challenge challenge = findChallengeByIdOrThrow(challengeId);
+        return toChallengeResponse(challenge);
+    }
+
+    private Challenge findChallengeByIdOrThrow(Long challengeId) {
+        return challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 챌린지입니다."));
+    }
+
     @Transactional
     public Long createChallenge(MemberResponse memberResponse, ChallengeRequest challengeRequest) {
         Member member = memberService.findMemberByIdOrThrow(memberResponse.id());

--- a/src/main/java/kakao/rebit/member/dto/MemberResponse.java
+++ b/src/main/java/kakao/rebit/member/dto/MemberResponse.java
@@ -1,0 +1,14 @@
+package kakao.rebit.member.dto;
+
+import kakao.rebit.member.entity.Role;
+
+public record MemberResponse(
+        Long id,
+        String nickname,
+        String imageUrl,
+        String bio,
+        Role role,
+        Integer point
+) {
+
+}

--- a/src/main/java/kakao/rebit/member/entity/Member.java
+++ b/src/main/java/kakao/rebit/member/entity/Member.java
@@ -17,7 +17,7 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String username;
+    private String nickname;
 
     private String imageUrl;
 
@@ -33,8 +33,8 @@ public class Member extends BaseEntity {
     protected Member() {
     }
 
-    public Member(String username, String imageUrl, String bio, Role role, Integer point, String kakaoToken) {
-        this.username = username;
+    public Member(String nickname, String imageUrl, String bio, Role role, Integer point, String kakaoToken) {
+        this.nickname = nickname;
         this.imageUrl = imageUrl;
         this.bio = bio;
         this.role = role;
@@ -46,8 +46,8 @@ public class Member extends BaseEntity {
         return id;
     }
 
-    public String getUsername() {
-        return username;
+    public String getNickname() {
+        return nickname;
     }
 
     public String getImageUrl() {

--- a/src/main/java/kakao/rebit/member/service/MemberService.java
+++ b/src/main/java/kakao/rebit/member/service/MemberService.java
@@ -1,0 +1,22 @@
+package kakao.rebit.member.service;
+
+import kakao.rebit.member.entity.Member;
+import kakao.rebit.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Member findMemberByIdOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+    }
+}


### PR DESCRIPTION
## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용 및 변경 사항
- 챌린지 엔티티 조회, 생성, 삭제 API 구현
- 회원 엔티티 `username` 필드를 ERD에 맞게 `nickname`으로 수정

## 이슈 링크
close #19 

