### PR TITLE
[FEAT] 피드 조회 구현

### DIFF
--- a/src/main/java/kakao/rebit/book/entity/Book.java
+++ b/src/main/java/kakao/rebit/book/entity/Book.java
@@ -2,6 +2,8 @@ package kakao.rebit.book.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import kakao.rebit.common.persistence.BaseEntity;
@@ -11,6 +13,9 @@ import kakao.rebit.common.persistence.BaseEntity;
 public class Book extends BaseEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     private String isbn;
 
     private String title;
@@ -27,13 +32,18 @@ public class Book extends BaseEntity {
     protected Book() {
     }
 
-    public Book(String isbn, String title, String description, String author, String publisher, String imageUrl) {
+    public Book(String isbn, String title, String description, String author, String publisher,
+            String imageUrl) {
         this.isbn = isbn;
         this.title = title;
         this.description = description;
         this.author = author;
         this.publisher = publisher;
         this.imageUrl = imageUrl;
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getIsbn() {

--- a/src/main/java/kakao/rebit/feed/controller/FavoriteBookController.java
+++ b/src/main/java/kakao/rebit/feed/controller/FavoriteBookController.java
@@ -1,0 +1,35 @@
+package kakao.rebit.feed.controller;
+
+import kakao.rebit.feed.dto.response.FavoriteBookResponse;
+import kakao.rebit.feed.service.FavoriteBookService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/favorites")
+public class FavoriteBookController {
+
+    private final FavoriteBookService favoriteBookService;
+
+    public FavoriteBookController(FavoriteBookService favoriteBookService) {
+        this.favoriteBookService = favoriteBookService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<FavoriteBookResponse>> getFavorites(
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok().body(favoriteBookService.getFavorites(pageable));
+    }
+
+    @GetMapping("/{favorite-id}")
+    public ResponseEntity<FavoriteBookResponse> getFavorite(@PathVariable("favorite-id") Long id) {
+        return ResponseEntity.ok().body(favoriteBookService.getFavoriteById(id));
+    }
+}

--- a/src/main/java/kakao/rebit/feed/controller/FavoriteBookController.java
+++ b/src/main/java/kakao/rebit/feed/controller/FavoriteBookController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/favorites")
+@RequestMapping("/api/feeds/favorite-books")
 public class FavoriteBookController {
 
     private final FavoriteBookService favoriteBookService;
@@ -23,13 +23,14 @@ public class FavoriteBookController {
     }
 
     @GetMapping
-    public ResponseEntity<Page<FavoriteBookResponse>> getFavorites(
+    public ResponseEntity<Page<FavoriteBookResponse>> getFavoriteBooks(
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok().body(favoriteBookService.getFavorites(pageable));
+        return ResponseEntity.ok().body(favoriteBookService.getFavoriteBooks(pageable));
     }
 
     @GetMapping("/{favorite-id}")
-    public ResponseEntity<FavoriteBookResponse> getFavorite(@PathVariable("favorite-id") Long id) {
-        return ResponseEntity.ok().body(favoriteBookService.getFavoriteById(id));
+    public ResponseEntity<FavoriteBookResponse> getFavoriteBook(
+            @PathVariable("favorite-id") Long id) {
+        return ResponseEntity.ok().body(favoriteBookService.getFavoriteBookById(id));
     }
 }

--- a/src/main/java/kakao/rebit/feed/controller/FeedController.java
+++ b/src/main/java/kakao/rebit/feed/controller/FeedController.java
@@ -1,0 +1,30 @@
+package kakao.rebit.feed.controller;
+
+import kakao.rebit.feed.dto.response.FeedResponse;
+import kakao.rebit.feed.service.FeedService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/feeds")
+public class FeedController {
+
+    private final FeedService feedService;
+
+    public FeedController(FeedService feedService) {
+        this.feedService = feedService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<FeedResponse>> getFeeds(
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return ResponseEntity.ok().body(feedService.getFeeds(pageable));
+    }
+}

--- a/src/main/java/kakao/rebit/feed/controller/MagazineController.java
+++ b/src/main/java/kakao/rebit/feed/controller/MagazineController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/magazines")
+@RequestMapping("/api/feeds/magazines")
 public class MagazineController {
 
     private final MagazineService magazineService;

--- a/src/main/java/kakao/rebit/feed/controller/MagazineController.java
+++ b/src/main/java/kakao/rebit/feed/controller/MagazineController.java
@@ -1,0 +1,35 @@
+package kakao.rebit.feed.controller;
+
+import kakao.rebit.feed.dto.response.MagazineResponse;
+import kakao.rebit.feed.service.MagazineService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/magazines")
+public class MagazineController {
+
+    private final MagazineService magazineService;
+
+    public MagazineController(MagazineService magazineService) {
+        this.magazineService = magazineService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<MagazineResponse>> getMagazines(
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok().body(magazineService.getMagazines(pageable));
+    }
+
+    @GetMapping("/{magazine-id}")
+    public ResponseEntity<MagazineResponse> getMagazine(@PathVariable("magazine-id") Long id) {
+        return ResponseEntity.ok().body(magazineService.getMagazineById(id));
+    }
+}

--- a/src/main/java/kakao/rebit/feed/controller/StoryController.java
+++ b/src/main/java/kakao/rebit/feed/controller/StoryController.java
@@ -1,0 +1,35 @@
+package kakao.rebit.feed.controller;
+
+import kakao.rebit.feed.dto.response.StoryResponse;
+import kakao.rebit.feed.service.StoryService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/stories")
+public class StoryController {
+
+    private final StoryService storyService;
+
+    public StoryController(StoryService storyService) {
+        this.storyService = storyService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<StoryResponse>> getStories(
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok().body(storyService.getStories(pageable));
+    }
+
+    @GetMapping("/{story-id}")
+    public ResponseEntity<StoryResponse> getStory(@PathVariable("story-id") Long id) {
+        return ResponseEntity.ok().body(storyService.getStoryById(id));
+    }
+}

--- a/src/main/java/kakao/rebit/feed/controller/StoryController.java
+++ b/src/main/java/kakao/rebit/feed/controller/StoryController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/stories")
+@RequestMapping("/api/feeds/stories")
 public class StoryController {
 
     private final StoryService storyService;

--- a/src/main/java/kakao/rebit/feed/dto/response/AuthorResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/AuthorResponse.java
@@ -1,0 +1,9 @@
+package kakao.rebit.feed.dto.response;
+
+public record AuthorResponse(
+        Long id,
+        String nickname,
+        String imageUrl
+) {
+
+}

--- a/src/main/java/kakao/rebit/feed/dto/response/BookResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/BookResponse.java
@@ -1,0 +1,13 @@
+package kakao.rebit.feed.dto.response;
+
+public record BookResponse(
+        Long id,
+        String isbn,
+        String title,
+        String description,
+        String author,
+        String publisher,
+        String imageUrl
+) {
+
+}

--- a/src/main/java/kakao/rebit/feed/dto/response/FavoriteBookResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/FavoriteBookResponse.java
@@ -1,17 +1,15 @@
 package kakao.rebit.feed.dto.response;
 
-import kakao.rebit.member.dto.MemberResponse;
-
 public class FavoriteBookResponse extends FeedResponse {
 
     private String briefReview;
     private String fullReview;
 
-    public FavoriteBookResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
+    public FavoriteBookResponse(Long id, AuthorResponse author, BookResponse book,
             String type,
             String briefReview,
             String fullReview) {
-        super(id, memberResponse, bookResponse, type);
+        super(id, author, book, type);
         this.briefReview = briefReview;
         this.fullReview = fullReview;
     }

--- a/src/main/java/kakao/rebit/feed/dto/response/FavoriteBookResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/FavoriteBookResponse.java
@@ -8,9 +8,10 @@ public class FavoriteBookResponse extends FeedResponse {
     private String fullReview;
 
     public FavoriteBookResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
+            String type,
             String briefReview,
             String fullReview) {
-        super(id, memberResponse, bookResponse, Type.FB);
+        super(id, memberResponse, bookResponse, type);
         this.briefReview = briefReview;
         this.fullReview = fullReview;
     }

--- a/src/main/java/kakao/rebit/feed/dto/response/FavoriteBookResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/FavoriteBookResponse.java
@@ -1,0 +1,26 @@
+package kakao.rebit.feed.dto.response;
+
+import kakao.rebit.member.dto.MemberResponse;
+
+public class FavoriteBookResponse extends FeedResponse {
+
+    private String briefReview;
+    private String fullReview;
+
+    public FavoriteBookResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
+            String briefReview,
+            String fullReview) {
+        super(id, memberResponse, bookResponse, Type.FB);
+        this.briefReview = briefReview;
+        this.fullReview = fullReview;
+    }
+
+    public String getBriefReview() {
+        return briefReview;
+    }
+
+    public String getFullReview() {
+        return fullReview;
+    }
+
+}

--- a/src/main/java/kakao/rebit/feed/dto/response/FeedResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/FeedResponse.java
@@ -1,19 +1,17 @@
 package kakao.rebit.feed.dto.response;
 
-import kakao.rebit.member.dto.MemberResponse;
-
 public abstract class FeedResponse {
 
     private Long id;
-    private MemberResponse memberResponse;
-    private BookResponse bookResponse;
+    private AuthorResponse author;
+    private BookResponse book;
     private String type;
 
-    public FeedResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
+    public FeedResponse(Long id, AuthorResponse author, BookResponse book,
             String type) {
         this.id = id;
-        this.memberResponse = memberResponse;
-        this.bookResponse = bookResponse;
+        this.author = author;
+        this.book = book;
         this.type = type;
     }
 
@@ -21,12 +19,12 @@ public abstract class FeedResponse {
         return id;
     }
 
-    public MemberResponse getMemberResponse() {
-        return memberResponse;
+    public AuthorResponse getAuthor() {
+        return author;
     }
 
-    public BookResponse getBookResponse() {
-        return bookResponse;
+    public BookResponse getBook() {
+        return book;
     }
 
     public String getType() {

--- a/src/main/java/kakao/rebit/feed/dto/response/FeedResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/FeedResponse.java
@@ -1,0 +1,35 @@
+package kakao.rebit.feed.dto.response;
+
+import kakao.rebit.member.dto.MemberResponse;
+
+public abstract class FeedResponse {
+
+    private Long id;
+    private MemberResponse memberResponse;
+    private BookResponse bookResponse;
+    private Type type;
+
+    public FeedResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
+            Type type) {
+        this.id = id;
+        this.memberResponse = memberResponse;
+        this.bookResponse = bookResponse;
+        this.type = type;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public MemberResponse getMemberResponse() {
+        return memberResponse;
+    }
+
+    public BookResponse getBookResponse() {
+        return bookResponse;
+    }
+
+    public Type getType() {
+        return type;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/dto/response/FeedResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/FeedResponse.java
@@ -7,10 +7,10 @@ public abstract class FeedResponse {
     private Long id;
     private MemberResponse memberResponse;
     private BookResponse bookResponse;
-    private Type type;
+    private String type;
 
     public FeedResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
-            Type type) {
+            String type) {
         this.id = id;
         this.memberResponse = memberResponse;
         this.bookResponse = bookResponse;
@@ -29,7 +29,7 @@ public abstract class FeedResponse {
         return bookResponse;
     }
 
-    public Type getType() {
+    public String getType() {
         return type;
     }
 }

--- a/src/main/java/kakao/rebit/feed/dto/response/MagazineResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/MagazineResponse.java
@@ -9,9 +9,8 @@ public class MagazineResponse extends FeedResponse {
     private String content;
 
     public MagazineResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
-            String name, String imageUrl,
-            String content) {
-        super(id, memberResponse, bookResponse, Type.M);
+            String type, String name, String imageUrl, String content) {
+        super(id, memberResponse, bookResponse, type);
         this.name = name;
         this.imageUrl = imageUrl;
         this.content = content;

--- a/src/main/java/kakao/rebit/feed/dto/response/MagazineResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/MagazineResponse.java
@@ -1,16 +1,14 @@
 package kakao.rebit.feed.dto.response;
 
-import kakao.rebit.member.dto.MemberResponse;
-
 public class MagazineResponse extends FeedResponse {
 
     private String name;
     private String imageUrl;
     private String content;
 
-    public MagazineResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
+    public MagazineResponse(Long id, AuthorResponse author, BookResponse book,
             String type, String name, String imageUrl, String content) {
-        super(id, memberResponse, bookResponse, type);
+        super(id, author, book, type);
         this.name = name;
         this.imageUrl = imageUrl;
         this.content = content;

--- a/src/main/java/kakao/rebit/feed/dto/response/MagazineResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/MagazineResponse.java
@@ -1,0 +1,31 @@
+package kakao.rebit.feed.dto.response;
+
+import kakao.rebit.member.dto.MemberResponse;
+
+public class MagazineResponse extends FeedResponse {
+
+    private String name;
+    private String imageUrl;
+    private String content;
+
+    public MagazineResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
+            String name, String imageUrl,
+            String content) {
+        super(id, memberResponse, bookResponse, Type.M);
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.content = content;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/dto/response/StoryResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/StoryResponse.java
@@ -1,0 +1,24 @@
+package kakao.rebit.feed.dto.response;
+
+import kakao.rebit.member.dto.MemberResponse;
+
+public class StoryResponse extends FeedResponse {
+
+    private String imageUrl;
+    private String content;
+
+    public StoryResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
+            String imageUrl, String content) {
+        super(id, memberResponse, bookResponse, Type.S);
+        this.imageUrl = imageUrl;
+        this.content = content;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/dto/response/StoryResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/StoryResponse.java
@@ -8,8 +8,8 @@ public class StoryResponse extends FeedResponse {
     private String content;
 
     public StoryResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
-            String imageUrl, String content) {
-        super(id, memberResponse, bookResponse, Type.S);
+            String type, String imageUrl, String content) {
+        super(id, memberResponse, bookResponse, type);
         this.imageUrl = imageUrl;
         this.content = content;
     }

--- a/src/main/java/kakao/rebit/feed/dto/response/StoryResponse.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/StoryResponse.java
@@ -1,15 +1,13 @@
 package kakao.rebit.feed.dto.response;
 
-import kakao.rebit.member.dto.MemberResponse;
-
 public class StoryResponse extends FeedResponse {
 
     private String imageUrl;
     private String content;
 
-    public StoryResponse(Long id, MemberResponse memberResponse, BookResponse bookResponse,
+    public StoryResponse(Long id, AuthorResponse author, BookResponse book,
             String type, String imageUrl, String content) {
-        super(id, memberResponse, bookResponse, type);
+        super(id, author, book, type);
         this.imageUrl = imageUrl;
         this.content = content;
     }

--- a/src/main/java/kakao/rebit/feed/dto/response/Type.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/Type.java
@@ -1,5 +1,0 @@
-package kakao.rebit.feed.dto.response;
-
-public enum Type {
-    FB, M, S
-}

--- a/src/main/java/kakao/rebit/feed/dto/response/Type.java
+++ b/src/main/java/kakao/rebit/feed/dto/response/Type.java
@@ -1,0 +1,5 @@
+package kakao.rebit.feed.dto.response;
+
+public enum Type {
+    FB, M, S
+}

--- a/src/main/java/kakao/rebit/feed/entity/Feed.java
+++ b/src/main/java/kakao/rebit/feed/entity/Feed.java
@@ -1,6 +1,7 @@
 package kakao.rebit.feed.entity;
 
 import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -39,6 +40,9 @@ public abstract class Feed extends BaseEntity {
     @JoinColumn(name = "book_id")
     private Book book;
 
+    @Column(name = "type", insertable = false, updatable = false)
+    private String type; // 상속 관계로 인해 생성된 type을 조회하기 위한 필드
+
     protected Feed() {
     }
 
@@ -61,5 +65,9 @@ public abstract class Feed extends BaseEntity {
 
     public Book getBook() {
         return book;
+    }
+
+    public String getType() {
+        return type;
     }
 }

--- a/src/main/java/kakao/rebit/feed/entity/Feed.java
+++ b/src/main/java/kakao/rebit/feed/entity/Feed.java
@@ -36,7 +36,7 @@ public abstract class Feed extends BaseEntity {
     private int likes;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "isbn")
+    @JoinColumn(name = "book_id")
     private Book book;
 
     protected Feed() {

--- a/src/main/java/kakao/rebit/feed/entity/Magazine.java
+++ b/src/main/java/kakao/rebit/feed/entity/Magazine.java
@@ -18,8 +18,7 @@ public class Magazine extends Feed {
     protected Magazine() {
     }
 
-    public Magazine(Member member, Book book, String name, String imageUrl,
-            String content) {
+    public Magazine(Member member, Book book, String name, String imageUrl, String content) {
         super(member, book);
         this.name = name;
         this.imageUrl = imageUrl;

--- a/src/main/java/kakao/rebit/feed/repository/FavoriteBookRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/FavoriteBookRepository.java
@@ -2,9 +2,7 @@ package kakao.rebit.feed.repository;
 
 import kakao.rebit.feed.entity.FavoriteBook;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface FavoriteBookRepository extends JpaRepository<FavoriteBook, Long> {
 
 }

--- a/src/main/java/kakao/rebit/feed/repository/FeedRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/FeedRepository.java
@@ -2,9 +2,7 @@ package kakao.rebit.feed.repository;
 
 import kakao.rebit.feed.entity.Feed;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 
 }

--- a/src/main/java/kakao/rebit/feed/repository/LikesRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/LikesRepository.java
@@ -2,9 +2,7 @@ package kakao.rebit.feed.repository;
 
 import kakao.rebit.feed.entity.Likes;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface LikesRepository extends JpaRepository<Likes, Long> {
 
 }

--- a/src/main/java/kakao/rebit/feed/repository/MagazineRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/MagazineRepository.java
@@ -2,9 +2,7 @@ package kakao.rebit.feed.repository;
 
 import kakao.rebit.feed.entity.Magazine;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
 
 }

--- a/src/main/java/kakao/rebit/feed/repository/MagazineRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/MagazineRepository.java
@@ -1,8 +1,10 @@
 package kakao.rebit.feed.repository;
 
+import kakao.rebit.feed.entity.Magazine;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MagazineRepository {
+public interface MagazineRepository extends JpaRepository<Magazine, Long> {
 
 }

--- a/src/main/java/kakao/rebit/feed/repository/StoryRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/StoryRepository.java
@@ -2,9 +2,7 @@ package kakao.rebit.feed.repository;
 
 import kakao.rebit.feed.entity.Story;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface StoryRepository extends JpaRepository<Story, Long> {
 
 }

--- a/src/main/java/kakao/rebit/feed/service/FavoriteBookService.java
+++ b/src/main/java/kakao/rebit/feed/service/FavoriteBookService.java
@@ -1,0 +1,60 @@
+package kakao.rebit.feed.service;
+
+import kakao.rebit.book.entity.Book;
+import kakao.rebit.feed.dto.response.BookResponse;
+import kakao.rebit.feed.dto.response.FavoriteBookResponse;
+import kakao.rebit.feed.entity.FavoriteBook;
+import kakao.rebit.feed.repository.FavoriteBookRepository;
+import kakao.rebit.member.dto.MemberResponse;
+import kakao.rebit.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class FavoriteBookService {
+
+    private final FavoriteBookRepository favoriteBookRepository;
+
+    public FavoriteBookService(FavoriteBookRepository favoriteBookRepository) {
+        this.favoriteBookRepository = favoriteBookRepository;
+    }
+
+    public Page<FavoriteBookResponse> getFavorites(Pageable pageable) {
+        Page<FavoriteBook> favorites = favoriteBookRepository.findAll(pageable);
+        System.out.println(favorites);
+        return favorites.map(this::toFavoriteBookResponse);
+    }
+
+    public FavoriteBookResponse getFavoriteById(Long id) {
+        FavoriteBook favoriteBook = favoriteBookRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("찾는 인생책이 없습니다."));
+        return toFavoriteBookResponse(favoriteBook);
+    }
+
+    /**
+     * 아래부터는 DTO 변환 로직
+     */
+
+    private FavoriteBookResponse toFavoriteBookResponse(FavoriteBook favoriteBook) {
+        return new FavoriteBookResponse(
+                favoriteBook.getId(),
+                toMemberResponse(favoriteBook.getMember()),
+                toBookResponse(favoriteBook.getBook()),
+                favoriteBook.getBriefReview(),
+                favoriteBook.getFullReview()
+        );
+    }
+
+    private MemberResponse toMemberResponse(Member member) {
+        return new MemberResponse(member.getId(), member.getNickname(), member.getImageUrl(),
+                member.getBio(), member.getRole(), member.getPoint());
+    }
+
+    private BookResponse toBookResponse(Book book) {
+        return new BookResponse(book.getId(), book.getIsbn(), book.getTitle(),
+                book.getDescription(), book.getAuthor(), book.getPublisher(), book.getImageUrl());
+    }
+}

--- a/src/main/java/kakao/rebit/feed/service/FavoriteBookService.java
+++ b/src/main/java/kakao/rebit/feed/service/FavoriteBookService.java
@@ -1,12 +1,8 @@
 package kakao.rebit.feed.service;
 
-import kakao.rebit.book.entity.Book;
-import kakao.rebit.feed.dto.response.BookResponse;
 import kakao.rebit.feed.dto.response.FavoriteBookResponse;
 import kakao.rebit.feed.entity.FavoriteBook;
 import kakao.rebit.feed.repository.FavoriteBookRepository;
-import kakao.rebit.member.dto.MemberResponse;
-import kakao.rebit.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,20 +12,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class FavoriteBookService {
 
     private final FavoriteBookRepository favoriteBookRepository;
+    private final FeedService feedService;
 
-    public FavoriteBookService(FavoriteBookRepository favoriteBookRepository) {
+    public FavoriteBookService(FavoriteBookRepository favoriteBookRepository,
+            FeedService feedService) {
         this.favoriteBookRepository = favoriteBookRepository;
+        this.feedService = feedService;
     }
 
     @Transactional(readOnly = true)
-    public Page<FavoriteBookResponse> getFavorites(Pageable pageable) {
+    public Page<FavoriteBookResponse> getFavoriteBooks(Pageable pageable) {
         Page<FavoriteBook> favorites = favoriteBookRepository.findAll(pageable);
         System.out.println(favorites);
         return favorites.map(this::toFavoriteBookResponse);
     }
 
     @Transactional(readOnly = true)
-    public FavoriteBookResponse getFavoriteById(Long id) {
+    public FavoriteBookResponse getFavoriteBookById(Long id) {
         FavoriteBook favoriteBook = favoriteBookRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("찾는 인생책이 없습니다."));
         return toFavoriteBookResponse(favoriteBook);
@@ -41,18 +40,9 @@ public class FavoriteBookService {
 
     private FavoriteBookResponse toFavoriteBookResponse(FavoriteBook favoriteBook) {
         return new FavoriteBookResponse(favoriteBook.getId(),
-                toMemberResponse(favoriteBook.getMember()), toBookResponse(favoriteBook.getBook()),
+                feedService.toAuthorResponse(favoriteBook.getMember()),
+                feedService.toBookResponse(favoriteBook.getBook()),
                 favoriteBook.getType(), favoriteBook.getBriefReview(),
                 favoriteBook.getFullReview());
-    }
-
-    private MemberResponse toMemberResponse(Member member) {
-        return new MemberResponse(member.getId(), member.getNickname(), member.getImageUrl(),
-                member.getBio(), member.getRole(), member.getPoint());
-    }
-
-    private BookResponse toBookResponse(Book book) {
-        return new BookResponse(book.getId(), book.getIsbn(), book.getTitle(),
-                book.getDescription(), book.getAuthor(), book.getPublisher(), book.getImageUrl());
     }
 }

--- a/src/main/java/kakao/rebit/feed/service/FavoriteBookService.java
+++ b/src/main/java/kakao/rebit/feed/service/FavoriteBookService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 public class FavoriteBookService {
 
     private final FavoriteBookRepository favoriteBookRepository;
@@ -22,12 +21,14 @@ public class FavoriteBookService {
         this.favoriteBookRepository = favoriteBookRepository;
     }
 
+    @Transactional(readOnly = true)
     public Page<FavoriteBookResponse> getFavorites(Pageable pageable) {
         Page<FavoriteBook> favorites = favoriteBookRepository.findAll(pageable);
         System.out.println(favorites);
         return favorites.map(this::toFavoriteBookResponse);
     }
 
+    @Transactional(readOnly = true)
     public FavoriteBookResponse getFavoriteById(Long id) {
         FavoriteBook favoriteBook = favoriteBookRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("찾는 인생책이 없습니다."));
@@ -39,13 +40,10 @@ public class FavoriteBookService {
      */
 
     private FavoriteBookResponse toFavoriteBookResponse(FavoriteBook favoriteBook) {
-        return new FavoriteBookResponse(
-                favoriteBook.getId(),
-                toMemberResponse(favoriteBook.getMember()),
-                toBookResponse(favoriteBook.getBook()),
-                favoriteBook.getBriefReview(),
-                favoriteBook.getFullReview()
-        );
+        return new FavoriteBookResponse(favoriteBook.getId(),
+                toMemberResponse(favoriteBook.getMember()), toBookResponse(favoriteBook.getBook()),
+                favoriteBook.getType(), favoriteBook.getBriefReview(),
+                favoriteBook.getFullReview());
     }
 
     private MemberResponse toMemberResponse(Member member) {

--- a/src/main/java/kakao/rebit/feed/service/FeedService.java
+++ b/src/main/java/kakao/rebit/feed/service/FeedService.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 public class FeedService {
 
     private final FeedRepository feedRepository;
@@ -28,6 +27,7 @@ public class FeedService {
         this.feedRepository = feedRepository;
     }
 
+    @Transactional(readOnly = true)
     public Page<FeedResponse> getFeeds(Pageable pageable) {
         return feedRepository.findAll(pageable).map(this::toFeedResponse);
     }
@@ -39,21 +39,21 @@ public class FeedService {
     private FeedResponse toFeedResponse(Feed feed) {
         if (feed instanceof FavoriteBook) {
             return new FavoriteBookResponse(feed.getId(), toMemberResponse(feed.getMember()),
-                    toBookResponse(feed.getBook()),
+                    toBookResponse(feed.getBook()), feed.getType(),
                     ((FavoriteBook) feed).getBriefReview(), ((FavoriteBook) feed).getFullReview());
         }
         if (feed instanceof Magazine) {
             return new MagazineResponse(feed.getId(), toMemberResponse(feed.getMember()),
-                    toBookResponse(feed.getBook()),
+                    toBookResponse(feed.getBook()), feed.getType(),
                     ((Magazine) feed).getName(), ((Magazine) feed).getImageUrl(),
                     ((Magazine) feed).getContent());
         }
         if (feed instanceof Story) {
             return new StoryResponse(feed.getId(), toMemberResponse(feed.getMember()),
-                    toBookResponse(feed.getBook()),
+                    toBookResponse(feed.getBook()), feed.getType(),
                     ((Story) feed).getImageUrl(), ((Story) feed).getContent());
         }
-        return null;
+        throw new IllegalStateException("유효하지 않는 피드입니다.");
     }
 
 

--- a/src/main/java/kakao/rebit/feed/service/FeedService.java
+++ b/src/main/java/kakao/rebit/feed/service/FeedService.java
@@ -1,0 +1,69 @@
+package kakao.rebit.feed.service;
+
+import kakao.rebit.book.entity.Book;
+import kakao.rebit.feed.dto.response.BookResponse;
+import kakao.rebit.feed.dto.response.FavoriteBookResponse;
+import kakao.rebit.feed.dto.response.FeedResponse;
+import kakao.rebit.feed.dto.response.MagazineResponse;
+import kakao.rebit.feed.dto.response.StoryResponse;
+import kakao.rebit.feed.entity.FavoriteBook;
+import kakao.rebit.feed.entity.Feed;
+import kakao.rebit.feed.entity.Magazine;
+import kakao.rebit.feed.entity.Story;
+import kakao.rebit.feed.repository.FeedRepository;
+import kakao.rebit.member.dto.MemberResponse;
+import kakao.rebit.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class FeedService {
+
+    private final FeedRepository feedRepository;
+
+    public FeedService(FeedRepository feedRepository) {
+        this.feedRepository = feedRepository;
+    }
+
+    public Page<FeedResponse> getFeeds(Pageable pageable) {
+        return feedRepository.findAll(pageable).map(this::toFeedResponse);
+    }
+
+    /**
+     * 아래부터는 DTO 변환 로직
+     */
+
+    private FeedResponse toFeedResponse(Feed feed) {
+        if (feed instanceof FavoriteBook) {
+            return new FavoriteBookResponse(feed.getId(), toMemberResponse(feed.getMember()),
+                    toBookResponse(feed.getBook()),
+                    ((FavoriteBook) feed).getBriefReview(), ((FavoriteBook) feed).getFullReview());
+        }
+        if (feed instanceof Magazine) {
+            return new MagazineResponse(feed.getId(), toMemberResponse(feed.getMember()),
+                    toBookResponse(feed.getBook()),
+                    ((Magazine) feed).getName(), ((Magazine) feed).getImageUrl(),
+                    ((Magazine) feed).getContent());
+        }
+        if (feed instanceof Story) {
+            return new StoryResponse(feed.getId(), toMemberResponse(feed.getMember()),
+                    toBookResponse(feed.getBook()),
+                    ((Story) feed).getImageUrl(), ((Story) feed).getContent());
+        }
+        return null;
+    }
+
+
+    private MemberResponse toMemberResponse(Member member) {
+        return new MemberResponse(member.getId(), member.getNickname(), member.getImageUrl(),
+                member.getBio(), member.getRole(), member.getPoint());
+    }
+
+    private BookResponse toBookResponse(Book book) {
+        return new BookResponse(book.getId(), book.getIsbn(), book.getTitle(),
+                book.getDescription(), book.getAuthor(), book.getPublisher(), book.getImageUrl());
+    }
+}

--- a/src/main/java/kakao/rebit/feed/service/FeedService.java
+++ b/src/main/java/kakao/rebit/feed/service/FeedService.java
@@ -1,6 +1,7 @@
 package kakao.rebit.feed.service;
 
 import kakao.rebit.book.entity.Book;
+import kakao.rebit.feed.dto.response.AuthorResponse;
 import kakao.rebit.feed.dto.response.BookResponse;
 import kakao.rebit.feed.dto.response.FavoriteBookResponse;
 import kakao.rebit.feed.dto.response.FeedResponse;
@@ -11,7 +12,6 @@ import kakao.rebit.feed.entity.Feed;
 import kakao.rebit.feed.entity.Magazine;
 import kakao.rebit.feed.entity.Story;
 import kakao.rebit.feed.repository.FeedRepository;
-import kakao.rebit.member.dto.MemberResponse;
 import kakao.rebit.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,18 +38,18 @@ public class FeedService {
 
     private FeedResponse toFeedResponse(Feed feed) {
         if (feed instanceof FavoriteBook) {
-            return new FavoriteBookResponse(feed.getId(), toMemberResponse(feed.getMember()),
+            return new FavoriteBookResponse(feed.getId(), toAuthorResponse(feed.getMember()),
                     toBookResponse(feed.getBook()), feed.getType(),
                     ((FavoriteBook) feed).getBriefReview(), ((FavoriteBook) feed).getFullReview());
         }
         if (feed instanceof Magazine) {
-            return new MagazineResponse(feed.getId(), toMemberResponse(feed.getMember()),
+            return new MagazineResponse(feed.getId(), toAuthorResponse(feed.getMember()),
                     toBookResponse(feed.getBook()), feed.getType(),
                     ((Magazine) feed).getName(), ((Magazine) feed).getImageUrl(),
                     ((Magazine) feed).getContent());
         }
         if (feed instanceof Story) {
-            return new StoryResponse(feed.getId(), toMemberResponse(feed.getMember()),
+            return new StoryResponse(feed.getId(), toAuthorResponse(feed.getMember()),
                     toBookResponse(feed.getBook()), feed.getType(),
                     ((Story) feed).getImageUrl(), ((Story) feed).getContent());
         }
@@ -57,12 +57,11 @@ public class FeedService {
     }
 
 
-    private MemberResponse toMemberResponse(Member member) {
-        return new MemberResponse(member.getId(), member.getNickname(), member.getImageUrl(),
-                member.getBio(), member.getRole(), member.getPoint());
+    public AuthorResponse toAuthorResponse(Member member) {
+        return new AuthorResponse(member.getId(), member.getNickname(), member.getImageUrl());
     }
 
-    private BookResponse toBookResponse(Book book) {
+    public BookResponse toBookResponse(Book book) {
         return new BookResponse(book.getId(), book.getIsbn(), book.getTitle(),
                 book.getDescription(), book.getAuthor(), book.getPublisher(), book.getImageUrl());
     }

--- a/src/main/java/kakao/rebit/feed/service/MagazineService.java
+++ b/src/main/java/kakao/rebit/feed/service/MagazineService.java
@@ -1,0 +1,59 @@
+package kakao.rebit.feed.service;
+
+import kakao.rebit.book.entity.Book;
+import kakao.rebit.feed.dto.response.BookResponse;
+import kakao.rebit.feed.dto.response.MagazineResponse;
+import kakao.rebit.feed.entity.Magazine;
+import kakao.rebit.feed.repository.MagazineRepository;
+import kakao.rebit.member.dto.MemberResponse;
+import kakao.rebit.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MagazineService {
+
+    private final MagazineRepository magazineRepository;
+
+    public MagazineService(MagazineRepository magazineRepository) {
+        this.magazineRepository = magazineRepository;
+    }
+
+    public Page<MagazineResponse> getMagazines(Pageable pageable) {
+        return magazineRepository.findAll(pageable).map(this::toMagazineResponse);
+    }
+
+    public MagazineResponse getMagazineById(Long id) {
+        Magazine magazine = magazineRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("찾는 Magazine이 없습니다."));
+        return toMagazineResponse(magazine);
+    }
+
+    private MagazineResponse toMagazineResponse(Magazine magazine) {
+        return new MagazineResponse(
+                magazine.getId(),
+                toMemberResponse(magazine.getMember()),
+                toBookResponse(magazine.getBook()),
+                magazine.getName(),
+                magazine.getImageUrl(),
+                magazine.getContent()
+        );
+    }
+
+    /**
+     * 아래부터는 DTO 변환 로직
+     */
+
+    private MemberResponse toMemberResponse(Member member) {
+        return new MemberResponse(member.getId(), member.getNickname(), member.getImageUrl(),
+                member.getBio(), member.getRole(), member.getPoint());
+    }
+
+    private BookResponse toBookResponse(Book book) {
+        return new BookResponse(book.getId(), book.getIsbn(), book.getTitle(),
+                book.getDescription(), book.getAuthor(), book.getPublisher(), book.getImageUrl());
+    }
+}

--- a/src/main/java/kakao/rebit/feed/service/MagazineService.java
+++ b/src/main/java/kakao/rebit/feed/service/MagazineService.java
@@ -1,12 +1,8 @@
 package kakao.rebit.feed.service;
 
-import kakao.rebit.book.entity.Book;
-import kakao.rebit.feed.dto.response.BookResponse;
 import kakao.rebit.feed.dto.response.MagazineResponse;
 import kakao.rebit.feed.entity.Magazine;
 import kakao.rebit.feed.repository.MagazineRepository;
-import kakao.rebit.member.dto.MemberResponse;
-import kakao.rebit.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,9 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class MagazineService {
 
     private final MagazineRepository magazineRepository;
+    private final FeedService feedService;
 
-    public MagazineService(MagazineRepository magazineRepository) {
+    public MagazineService(MagazineRepository magazineRepository, FeedService feedService) {
         this.magazineRepository = magazineRepository;
+        this.feedService = feedService;
     }
 
     @Transactional(readOnly = true)
@@ -36,26 +34,12 @@ public class MagazineService {
     private MagazineResponse toMagazineResponse(Magazine magazine) {
         return new MagazineResponse(
                 magazine.getId(),
-                toMemberResponse(magazine.getMember()),
-                toBookResponse(magazine.getBook()),
+                feedService.toAuthorResponse(magazine.getMember()),
+                feedService.toBookResponse(magazine.getBook()),
                 magazine.getType(),
                 magazine.getName(),
                 magazine.getImageUrl(),
                 magazine.getContent()
         );
-    }
-
-    /**
-     * 아래부터는 DTO 변환 로직
-     */
-
-    private MemberResponse toMemberResponse(Member member) {
-        return new MemberResponse(member.getId(), member.getNickname(), member.getImageUrl(),
-                member.getBio(), member.getRole(), member.getPoint());
-    }
-
-    private BookResponse toBookResponse(Book book) {
-        return new BookResponse(book.getId(), book.getIsbn(), book.getTitle(),
-                book.getDescription(), book.getAuthor(), book.getPublisher(), book.getImageUrl());
     }
 }

--- a/src/main/java/kakao/rebit/feed/service/MagazineService.java
+++ b/src/main/java/kakao/rebit/feed/service/MagazineService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 public class MagazineService {
 
     private final MagazineRepository magazineRepository;
@@ -22,10 +21,12 @@ public class MagazineService {
         this.magazineRepository = magazineRepository;
     }
 
+    @Transactional(readOnly = true)
     public Page<MagazineResponse> getMagazines(Pageable pageable) {
         return magazineRepository.findAll(pageable).map(this::toMagazineResponse);
     }
 
+    @Transactional(readOnly = true)
     public MagazineResponse getMagazineById(Long id) {
         Magazine magazine = magazineRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("찾는 Magazine이 없습니다."));
@@ -37,6 +38,7 @@ public class MagazineService {
                 magazine.getId(),
                 toMemberResponse(magazine.getMember()),
                 toBookResponse(magazine.getBook()),
+                magazine.getType(),
                 magazine.getName(),
                 magazine.getImageUrl(),
                 magazine.getContent()

--- a/src/main/java/kakao/rebit/feed/service/StoryService.java
+++ b/src/main/java/kakao/rebit/feed/service/StoryService.java
@@ -1,0 +1,59 @@
+package kakao.rebit.feed.service;
+
+import kakao.rebit.book.entity.Book;
+import kakao.rebit.feed.dto.response.BookResponse;
+import kakao.rebit.feed.dto.response.StoryResponse;
+import kakao.rebit.feed.entity.Story;
+import kakao.rebit.feed.repository.StoryRepository;
+import kakao.rebit.member.dto.MemberResponse;
+import kakao.rebit.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class StoryService {
+
+    private final StoryRepository storyRepository;
+
+    public StoryService(StoryRepository storyRepository) {
+        this.storyRepository = storyRepository;
+    }
+
+    public Page<StoryResponse> getStories(Pageable pageable) {
+        return storyRepository.findAll(pageable).map(this::toStoryResponse);
+    }
+
+    public StoryResponse getStoryById(Long id) {
+        Story story = storyRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("찾는 스토리가 없습니다."));
+        return toStoryResponse(story);
+    }
+
+    /**
+     * 아래부터는 DTO 변환 로직
+     */
+
+    private StoryResponse toStoryResponse(Story story) {
+        return new StoryResponse(
+                story.getId(),
+                toMemberResponse(story.getMember()),
+                toBookResponse(story.getBook()),
+                story.getImageUrl(),
+                story.getContent()
+        );
+    }
+
+    private MemberResponse toMemberResponse(Member member) {
+        return new MemberResponse(member.getId(), member.getNickname(), member.getImageUrl(),
+                member.getBio(), member.getRole(), member.getPoint());
+    }
+
+    private BookResponse toBookResponse(Book book) {
+        return new BookResponse(book.getId(), book.getIsbn(), book.getTitle(),
+                book.getDescription(), book.getAuthor(), book.getPublisher(), book.getImageUrl());
+    }
+
+}

--- a/src/main/java/kakao/rebit/feed/service/StoryService.java
+++ b/src/main/java/kakao/rebit/feed/service/StoryService.java
@@ -1,12 +1,8 @@
 package kakao.rebit.feed.service;
 
-import kakao.rebit.book.entity.Book;
-import kakao.rebit.feed.dto.response.BookResponse;
 import kakao.rebit.feed.dto.response.StoryResponse;
 import kakao.rebit.feed.entity.Story;
 import kakao.rebit.feed.repository.StoryRepository;
-import kakao.rebit.member.dto.MemberResponse;
-import kakao.rebit.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,9 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class StoryService {
 
     private final StoryRepository storyRepository;
+    private final FeedService feedService;
 
-    public StoryService(StoryRepository storyRepository) {
+    public StoryService(StoryRepository storyRepository, FeedService feedService) {
         this.storyRepository = storyRepository;
+        this.feedService = feedService;
     }
 
     @Transactional(readOnly = true)
@@ -40,22 +38,11 @@ public class StoryService {
     private StoryResponse toStoryResponse(Story story) {
         return new StoryResponse(
                 story.getId(),
-                toMemberResponse(story.getMember()),
-                toBookResponse(story.getBook()),
+                feedService.toAuthorResponse(story.getMember()),
+                feedService.toBookResponse(story.getBook()),
                 story.getType(),
                 story.getImageUrl(),
                 story.getContent()
         );
     }
-
-    private MemberResponse toMemberResponse(Member member) {
-        return new MemberResponse(member.getId(), member.getNickname(), member.getImageUrl(),
-                member.getBio(), member.getRole(), member.getPoint());
-    }
-
-    private BookResponse toBookResponse(Book book) {
-        return new BookResponse(book.getId(), book.getIsbn(), book.getTitle(),
-                book.getDescription(), book.getAuthor(), book.getPublisher(), book.getImageUrl());
-    }
-
 }

--- a/src/main/java/kakao/rebit/feed/service/StoryService.java
+++ b/src/main/java/kakao/rebit/feed/service/StoryService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 public class StoryService {
 
     private final StoryRepository storyRepository;
@@ -22,10 +21,12 @@ public class StoryService {
         this.storyRepository = storyRepository;
     }
 
+    @Transactional(readOnly = true)
     public Page<StoryResponse> getStories(Pageable pageable) {
         return storyRepository.findAll(pageable).map(this::toStoryResponse);
     }
 
+    @Transactional(readOnly = true)
     public StoryResponse getStoryById(Long id) {
         Story story = storyRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("찾는 스토리가 없습니다."));
@@ -41,6 +42,7 @@ public class StoryService {
                 story.getId(),
                 toMemberResponse(story.getMember()),
                 toBookResponse(story.getBook()),
+                story.getType(),
                 story.getImageUrl(),
                 story.getContent()
         );


### PR DESCRIPTION
## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용 및 변경 사항
- feed 전체 조회, 상세 조회 구현
- 응답을 위한 dto 구현


## 이슈 링크
close #16 

## 참고사항
- Feed 연관 관계로 인해 Book 기본키 수정했습니다.
- DTO record로 만드려고 했으나 상속으로 구현하는 게  중복 코드도 줄이고 피드를 한번에 조회할 때 다형성을 사용하는게 더 좋다고 생각해서 일반 class로 구현하였습니다.  이 부분에 대해서는 더 좋은 방법이 있을지 의견 듣고 싶습니다.
- Feed와 Feed 하위 항목들을 묶어서 한번에 컨트롤러, 서비스를 작성할지 아니면 각각 작성할지 고민하다가 그냥 각각 작성하는 게 저는 보기 더 편한 것 같아서 각각 작성했는데 다른 분들은 어떻게 생각하시는지 궁금합니다. 