### PR TITLE
[FEAT] 카카오소셜로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,14 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // JJWT 관련 의존성 추가
+    compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // 테스트용
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/src/main/java/kakao/rebit/auth/Token/AuthToken.java
+++ b/src/main/java/kakao/rebit/auth/Token/AuthToken.java
@@ -1,0 +1,37 @@
+package kakao.rebit.auth.Token;
+
+public class AuthToken {
+
+    private String accessToken;
+    private String refreshToken;
+    private String grantType;
+    private Long expiresIn;
+
+    public AuthToken(String accessToken, String refreshToken, String grantType, Long expiresIn) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.grantType = grantType;
+        this.expiresIn = expiresIn;
+    }
+
+    public static AuthToken of(String accessToken, String refreshToken, String grantType,
+        Long expiresIn) {
+        return new AuthToken(accessToken, refreshToken, grantType, expiresIn);
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public String getGrantType() {
+        return grantType;
+    }
+
+    public Long getExpiresIn() {
+        return expiresIn;
+    }
+}

--- a/src/main/java/kakao/rebit/auth/Token/AuthTokenGenerator.java
+++ b/src/main/java/kakao/rebit/auth/Token/AuthTokenGenerator.java
@@ -1,0 +1,29 @@
+package kakao.rebit.auth.Token;
+
+import kakao.rebit.auth.jwt.JwtTokenProvider;
+import org.springframework.stereotype.Component;
+import java.util.Date;
+
+@Component
+public class AuthTokenGenerator {
+
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 3600000;
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1209600000;
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthTokenGenerator(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public AuthToken generate(String uid) {
+        Date now = new Date();
+        Date accessTokenExpiry = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME);
+        Date refreshTokenExpiry = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME);
+
+        String accessToken = jwtTokenProvider.accessTokenGenerate(uid, accessTokenExpiry);
+        String refreshToken = jwtTokenProvider.refreshTokenGenerate(refreshTokenExpiry);
+
+        return AuthToken.of(accessToken, refreshToken, "Bearer", ACCESS_TOKEN_EXPIRE_TIME / 1000);
+    }
+}

--- a/src/main/java/kakao/rebit/auth/config/WebConfig.java
+++ b/src/main/java/kakao/rebit/auth/config/WebConfig.java
@@ -1,0 +1,20 @@
+package kakao.rebit.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/kakao/rebit/auth/controller/KakaoAuthController.java
+++ b/src/main/java/kakao/rebit/auth/controller/KakaoAuthController.java
@@ -1,0 +1,44 @@
+package kakao.rebit.auth.controller;
+
+import kakao.rebit.auth.dto.LoginResponse;
+import kakao.rebit.auth.service.KakaoAuthService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequestMapping("/api/auth")
+public class KakaoAuthController {
+
+    @Value("${OAUTH_KAKAO_CLIENT_ID}")
+    private String clientId;
+
+    @Value("${OAUTH_KAKAO_REDIRECT_URI}")
+    private String redirectUri;
+
+    private final KakaoAuthService kakaoAuthService;
+
+    public KakaoAuthController(KakaoAuthService kakaoAuthService) {
+        this.kakaoAuthService = kakaoAuthService;
+    }
+
+    // 테스트용 html
+    // 로그인 버튼을 클릭하면 인가코드를 받아옵니다.
+    @GetMapping("/login")
+    public String showLoginForm(Model model) {
+        model.addAttribute("clientId", clientId);
+        model.addAttribute("redirectUri", redirectUri);
+        return "loginForm";
+    }
+
+    @GetMapping("/login/oauth/kakao")
+    @ResponseBody
+    public LoginResponse kakaoLogin(@RequestParam String code) {
+
+        return kakaoAuthService.kakaoLogin(code, "localhost");
+    }
+}

--- a/src/main/java/kakao/rebit/auth/controller/KakaoAuthController.java
+++ b/src/main/java/kakao/rebit/auth/controller/KakaoAuthController.java
@@ -39,6 +39,6 @@ public class KakaoAuthController {
     @ResponseBody
     public LoginResponse kakaoLogin(@RequestParam String code) {
 
-        return kakaoAuthService.kakaoLogin(code, "localhost");
+        return kakaoAuthService.kakaoLogin(code);
     }
 }

--- a/src/main/java/kakao/rebit/auth/dto/KakaoToken.java
+++ b/src/main/java/kakao/rebit/auth/dto/KakaoToken.java
@@ -1,0 +1,41 @@
+package kakao.rebit.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KakaoToken {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private int expiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public int getExpiresIn() {
+        return expiresIn;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+}

--- a/src/main/java/kakao/rebit/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/kakao/rebit/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,17 @@
+package kakao.rebit.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserInfo(
+    @JsonProperty("id") Long id,
+    @JsonProperty("kakao_account") KakaoAccount kakaoAccount,
+    @JsonProperty("properties") Properties properties
+) {
+    public record KakaoAccount(
+        @JsonProperty("email") String email
+    ) {}
+
+    public record Properties(
+        @JsonProperty("nickname") String nickname
+    ) {}
+}

--- a/src/main/java/kakao/rebit/auth/dto/LoginResponse.java
+++ b/src/main/java/kakao/rebit/auth/dto/LoginResponse.java
@@ -1,0 +1,19 @@
+package kakao.rebit.auth.dto;
+
+import kakao.rebit.auth.Token.AuthToken;
+
+public class LoginResponse {
+
+    private AuthToken token;
+
+    public LoginResponse() {
+    }
+
+    public LoginResponse(AuthToken token) {
+        this.token = token;
+    }
+
+    public AuthToken getToken() {
+        return token;
+    }
+}

--- a/src/main/java/kakao/rebit/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/kakao/rebit/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,34 @@
+package kakao.rebit.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey key;
+
+    public JwtTokenProvider(@Value("${custom.jwt.secretKey}") String base64Secret) {
+        this.key = Keys.hmacShaKeyFor(java.util.Base64.getDecoder().decode(base64Secret));
+    }
+
+    public String accessTokenGenerate(String uid, Date expiryDate) {
+        return Jwts.builder()
+            .setSubject(uid)
+            .setExpiration(expiryDate)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public String refreshTokenGenerate(Date expiryDate) {
+        return Jwts.builder()
+            .setExpiration(expiryDate)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+    }
+}

--- a/src/main/java/kakao/rebit/auth/service/KakaoApiClient.java
+++ b/src/main/java/kakao/rebit/auth/service/KakaoApiClient.java
@@ -45,13 +45,7 @@ public class KakaoApiClient {
         HttpHeaders headers = new HttpHeaders();
         headers.add(CONTENT_TYPE, APPLICATION_FORM_URLENCODED);
 
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("redirect_uri", redirectUri);
-        params.add("code", code);
-
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(createTokenParams(code), headers);
         String tokenUrl = kakaoAuthUrl + "/oauth/token";
 
         ResponseEntity<String> response = restTemplate.exchange(
@@ -73,6 +67,15 @@ public class KakaoApiClient {
         } catch (Exception e) {
             throw new RuntimeException("액세스 토큰을 파싱하는 데 실패했습니다.", e);
         }
+    }
+
+    private MultiValueMap<String, String> createTokenParams(String code) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+        return params;
     }
 
     public HashMap<String, Object> getUserInfo(String accessToken) {

--- a/src/main/java/kakao/rebit/auth/service/KakaoApiClient.java
+++ b/src/main/java/kakao/rebit/auth/service/KakaoApiClient.java
@@ -1,0 +1,125 @@
+package kakao.rebit.auth.service;
+
+import java.util.HashMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Service
+public class KakaoApiClient {
+
+    private static final String CONTENT_TYPE = "Content-type";
+    private static final String APPLICATION_FORM_URLENCODED = "application/x-www-form-urlencoded;charset=utf-8";
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Value("${OAUTH_KAKAO_CLIENT_ID}")
+    private String clientId;
+
+    @Value("${OAUTH_KAKAO_REDIRECT_URI}")
+    private String redirectUri;
+
+    @Value("${OAUTH_KAKAO_AUTH_URL}")
+    private String kakaoAuthUrl;
+
+    @Value("${OAUTH_KAKAO_API_URL}")
+    private String kakaoApiUrl;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public KakaoApiClient(RestTemplate restTemplate, ObjectMapper objectMapper) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public String getAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(CONTENT_TYPE, APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        String tokenUrl = kakaoAuthUrl + "/oauth/token";
+
+        ResponseEntity<String> response = restTemplate.exchange(
+            tokenUrl,
+            HttpMethod.POST,
+            request,
+            String.class
+        );
+
+        try {
+            JsonNode rootNode = objectMapper.readTree(response.getBody());
+            String accessToken = rootNode.path("access_token").asText();
+
+            if (accessToken == null || accessToken.isEmpty()) {
+                throw new RuntimeException("액세스 토큰을 가져오지 못했습니다.");
+            }
+
+            return accessToken;
+        } catch (Exception e) {
+            throw new RuntimeException("액세스 토큰을 파싱하는 데 실패했습니다.", e);
+        }
+    }
+
+    public HashMap<String, Object> getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(AUTHORIZATION, BEARER_PREFIX + accessToken);
+        headers.add(CONTENT_TYPE, APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<?> request = new HttpEntity<>(headers);
+        String userInfoUrl = kakaoApiUrl + "/v2/user/me";
+
+        ResponseEntity<String> response = restTemplate.exchange(
+            userInfoUrl,
+            HttpMethod.POST,
+            request,
+            String.class
+        );
+
+        System.out.println("카카오 API 응답: " + response.getBody());
+
+        HashMap<String, Object> userInfo = new HashMap<>();
+        try {
+            JsonNode jsonNode = objectMapper.readTree(response.getBody());
+
+            JsonNode idNode = jsonNode.get("id");
+            if (idNode != null) {
+                userInfo.put("id", idNode.asLong());
+            } else {
+                throw new RuntimeException("응답에 ID 필드가 없습니다.");
+            }
+
+            JsonNode kakaoAccountNode = jsonNode.path("kakao_account");
+            if (kakaoAccountNode != null && kakaoAccountNode.get("email") != null) {
+                userInfo.put("email", kakaoAccountNode.get("email").asText());
+            } else {
+                userInfo.put("email", null);
+            }
+
+            JsonNode propertiesNode = jsonNode.path("properties");
+            if (propertiesNode != null && propertiesNode.get("nickname") != null) {
+                userInfo.put("nickname", propertiesNode.get("nickname").asText());
+            } else {
+                userInfo.put("nickname", null);
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("사용자 정보를 파싱하는 데 실패했습니다.", e);
+        }
+        return userInfo;
+    }
+}

--- a/src/main/java/kakao/rebit/auth/service/KakaoAuthService.java
+++ b/src/main/java/kakao/rebit/auth/service/KakaoAuthService.java
@@ -27,7 +27,7 @@ public class KakaoAuthService {
         this.authTokensGenerator = authTokensGenerator;
     }
 
-    public LoginResponse kakaoLogin(String code, String currentDomain) {
+    public LoginResponse kakaoLogin(String code) {
         // 1. 카카오로부터 액세스 토큰을 받음
         String accessToken = kakaoApiClient.getAccessToken(code);
 

--- a/src/main/java/kakao/rebit/auth/service/KakaoAuthService.java
+++ b/src/main/java/kakao/rebit/auth/service/KakaoAuthService.java
@@ -1,0 +1,55 @@
+package kakao.rebit.auth.service;
+
+import kakao.rebit.auth.Token.AuthTokenGenerator;
+import kakao.rebit.auth.dto.LoginResponse;
+import kakao.rebit.auth.Token.AuthToken;
+import kakao.rebit.member.entity.Member;
+import kakao.rebit.member.entity.Role;
+import kakao.rebit.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+@Service
+public class KakaoAuthService {
+
+    private final KakaoApiClient kakaoApiClient;
+    private final MemberRepository memberRepository;
+    private final AuthTokenGenerator authTokensGenerator;
+
+    @Autowired
+    public KakaoAuthService(KakaoApiClient kakaoApiClient, MemberRepository memberRepository,
+        AuthTokenGenerator authTokensGenerator) {
+        this.kakaoApiClient = kakaoApiClient;
+        this.memberRepository = memberRepository;
+        this.authTokensGenerator = authTokensGenerator;
+    }
+
+    public LoginResponse kakaoLogin(String code, String currentDomain) {
+        // 1. 카카오로부터 액세스 토큰을 받음
+        String accessToken = kakaoApiClient.getAccessToken(code);
+
+        // 2. 받은 액세스 토큰으로 유저 정보를 가져옴
+        HashMap<String, Object> userInfo = kakaoApiClient.getUserInfo(accessToken);
+        Long kakaoId = (Long) userInfo.get("id");
+        String nickname = (String) userInfo.get("nickname");
+
+        // 3. 카카오 토큰으로 기존 유저 조회
+        Optional<Member> memberOptional = memberRepository.findByKakaoToken(accessToken);
+
+        Member member = memberOptional.orElseGet(() -> {
+            // 회원이 없으면 회원가입 처리, 기본 Role은 ROLE_USER로 설정
+            Member newMember = new Member(nickname, null, null, Role.ROLE_USER, null, accessToken);
+            memberRepository.save(newMember);
+            return newMember;
+        });
+
+        // 4. 자체 JWT 토큰 생성
+        AuthToken tokens = authTokensGenerator.generate(member.getId().toString());
+
+        // 5. 로그인 응답 반환
+        return new LoginResponse(tokens);
+    }
+}

--- a/src/main/java/kakao/rebit/member/entity/Member.java
+++ b/src/main/java/kakao/rebit/member/entity/Member.java
@@ -23,6 +23,8 @@ public class Member extends BaseEntity {
 
     private String bio;
 
+    private String email;
+
     @Enumerated(EnumType.STRING)
     private Role role;
 
@@ -33,10 +35,11 @@ public class Member extends BaseEntity {
     protected Member() {
     }
 
-    public Member(String nickname, String imageUrl, String bio, Role role, Integer point, String kakaoToken) {
+    public Member(String nickname, String imageUrl, String bio, String email, Role role, Integer point, String kakaoToken) {
         this.nickname = nickname;
         this.imageUrl = imageUrl;
         this.bio = bio;
+        this.email = email;
         this.role = role;
         this.point = point;
         this.kakaoToken = kakaoToken;
@@ -56,6 +59,10 @@ public class Member extends BaseEntity {
 
     public String getBio() {
         return bio;
+    }
+
+    public String getEmail() {
+        return email;
     }
 
     public Role getRole() {

--- a/src/main/java/kakao/rebit/member/repository/MemberRepository.java
+++ b/src/main/java/kakao/rebit/member/repository/MemberRepository.java
@@ -1,8 +1,11 @@
 package kakao.rebit.member.repository;
 
+import java.util.Optional;
 import kakao.rebit.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByKakaoToken(String kakaoToken);
 
 }

--- a/src/main/java/kakao/rebit/member/repository/MemberRepository.java
+++ b/src/main/java/kakao/rebit/member/repository/MemberRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByKakaoToken(String kakaoToken);
+    Optional<Member> findByEmail(String email);
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,8 +29,12 @@ oauth:
       auth-url: ${OAUTH_KAKAO_AUTH_URL}
       api-url: ${OAUTH_KAKAO_API_URL}
       redirect-url: ${OAUTH_KAKAO_REDIRECT_URI}
-      logout-redirect-url:  ${OAUTH_KAKAO_LOGOUT_REDIRECT_URI}
+      logout-redirect-url: ${OAUTH_KAKAO_LOGOUT_REDIRECT_URI}
 
+# Jwt 시크릿 키 설정
+custom:
+  jwt:
+    secretKey: ${JWT_SECRET_KEY}
 
 logging:
   level:

--- a/src/main/resources/templates/loginForm.html
+++ b/src/main/resources/templates/loginForm.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>Kakao Login</title>
+</head>
+<body>
+<h1>카카오 로그인</h1>
+<a th:href="|https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code|">
+  <button>카카오 로그인</button>
+</a>
+</body>
+</html>


### PR DESCRIPTION
## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용 및 변경 사항
- 카카오 소셜로그인 구현
- 카카오 토큰을 사용해 유저 검색
- jwt 토큰 생성하여 프론트로 반환

## 이슈 링크
close #21

## 참고사항
- 로그인 성공 시 db에 유저 생성되는 것 확인했습니다. 그런데 닉네임 부분이 ??로 뜨는 걸 보니 인코딩에 문제가 있거나 닉네임을 제대로 가져오지 못하는 것 같아서 수정해야할 것 같습니다..
- 로그인 확인을 위해 /login 에서 로그인 폼 html을 반환하도록 되어있고 리다이렉트 uri가 localhost:8080으로 되어있습니다. 추후 함께 수정해두겠습니다..!