### PR TITLE
[FEAT] 피드 생성, 수정, 삭제 구현

### DIFF
--- a/src/main/java/kakao/rebit/auth/controller/KakaoAuthController.java
+++ b/src/main/java/kakao/rebit/auth/controller/KakaoAuthController.java
@@ -37,7 +37,7 @@ public class KakaoAuthController {
 
     @GetMapping("/login/oauth/kakao")
     @ResponseBody
-    public LoginResponse kakaoLogin(@RequestParam String code) {
+    public LoginResponse kakaoLogin(@RequestParam("code") String code) {
 
         return kakaoAuthService.kakaoLogin(code);
     }

--- a/src/main/java/kakao/rebit/feed/controller/FeedController.java
+++ b/src/main/java/kakao/rebit/feed/controller/FeedController.java
@@ -1,13 +1,23 @@
 package kakao.rebit.feed.controller;
 
+import java.net.URI;
+import kakao.rebit.feed.dto.request.create.CreateFeedRequest;
+import kakao.rebit.feed.dto.request.update.UpdateFeedRequest;
 import kakao.rebit.feed.dto.response.FeedResponse;
 import kakao.rebit.feed.service.FeedService;
+import kakao.rebit.member.dto.MemberResponse;
+import kakao.rebit.member.entity.Role;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,5 +36,33 @@ public class FeedController {
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return ResponseEntity.ok().body(feedService.getFeeds(pageable));
+    }
+
+    @GetMapping("/{feed-id}")
+    public ResponseEntity<FeedResponse> getMagazine(@PathVariable("feed-id") Long feedId) {
+        return ResponseEntity.ok().body(feedService.getFeedById(feedId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createFeed(@RequestBody CreateFeedRequest feedRequest) {
+        MemberResponse memberResponse = new MemberResponse(1L, "testUser", "imageUrl", "bio",
+                Role.ROLE_USER, 10000);
+        Long feedId = feedService.createFeed(memberResponse, feedRequest);
+        return ResponseEntity.created(URI.create("/api/feeds/" + feedId)).build();
+    }
+
+    @PutMapping("/{feed-id}")
+    public ResponseEntity<Void> updateFeed(@PathVariable("feed-id") Long feedId,
+            @RequestBody UpdateFeedRequest feedRequest) {
+        MemberResponse memberResponse = new MemberResponse(1L, "testUser", "imageUrl", "bio",
+                Role.ROLE_USER, 10000);
+        feedService.updateFeed(memberResponse, feedId, feedRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{feed-id}")
+    public ResponseEntity<Void> deleteFeed(@PathVariable("feed-id") Long feedId) {
+        feedService.deleteFeedById(feedId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/kakao/rebit/feed/dto/request/create/CreateFavoriteBookRequest.java
+++ b/src/main/java/kakao/rebit/feed/dto/request/create/CreateFavoriteBookRequest.java
@@ -3,7 +3,6 @@ package kakao.rebit.feed.dto.request.create;
 public class CreateFavoriteBookRequest extends CreateFeedRequest {
 
     private String briefReview;
-
     private String fullReview;
 
     private CreateFavoriteBookRequest() {

--- a/src/main/java/kakao/rebit/feed/dto/request/create/CreateFavoriteBookRequest.java
+++ b/src/main/java/kakao/rebit/feed/dto/request/create/CreateFavoriteBookRequest.java
@@ -1,0 +1,25 @@
+package kakao.rebit.feed.dto.request.create;
+
+public class CreateFavoriteBookRequest extends CreateFeedRequest {
+
+    private String briefReview;
+
+    private String fullReview;
+
+    private CreateFavoriteBookRequest() {
+    }
+
+    public CreateFavoriteBookRequest(Long bookId, String briefReview, String fullReview) {
+        super(bookId);
+        this.briefReview = briefReview;
+        this.fullReview = fullReview;
+    }
+
+    public String getBriefReview() {
+        return briefReview;
+    }
+
+    public String getFullReview() {
+        return fullReview;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/dto/request/create/CreateFeedRequest.java
+++ b/src/main/java/kakao/rebit/feed/dto/request/create/CreateFeedRequest.java
@@ -1,0 +1,30 @@
+package kakao.rebit.feed.dto.request.create;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type"
+)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = CreateFavoriteBookRequest.class, name = "FB"),
+        @JsonSubTypes.Type(value = CreateMagazineRequest.class, name = "M"),
+        @JsonSubTypes.Type(value = CreateStoryRequest.class, name = "S")
+})
+public abstract class CreateFeedRequest {
+
+    private Long bookId;
+
+    protected CreateFeedRequest() {
+    }
+
+    public CreateFeedRequest(Long bookId) {
+        this.bookId = bookId;
+    }
+
+    public Long getBookId() {
+        return bookId;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/dto/request/create/CreateMagazineRequest.java
+++ b/src/main/java/kakao/rebit/feed/dto/request/create/CreateMagazineRequest.java
@@ -1,0 +1,30 @@
+package kakao.rebit.feed.dto.request.create;
+
+public class CreateMagazineRequest extends CreateFeedRequest {
+
+    private String name;
+    private String imageUrl;
+    private String content;
+
+    private CreateMagazineRequest() {
+    }
+
+    public CreateMagazineRequest(Long bookId, String name, String imageUrl, String content) {
+        super(bookId);
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.content = content;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/dto/request/create/CreateStoryRequest.java
+++ b/src/main/java/kakao/rebit/feed/dto/request/create/CreateStoryRequest.java
@@ -1,0 +1,24 @@
+package kakao.rebit.feed.dto.request.create;
+
+public class CreateStoryRequest extends CreateFeedRequest {
+
+    private String imageUrl;
+    private String content;
+
+    private CreateStoryRequest() {
+    }
+
+    public CreateStoryRequest(Long bookId, String imageUrl, String content) {
+        super(bookId);
+        this.imageUrl = imageUrl;
+        this.content = content;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/dto/request/update/UpdateFavoriteBookRequest.java
+++ b/src/main/java/kakao/rebit/feed/dto/request/update/UpdateFavoriteBookRequest.java
@@ -1,0 +1,25 @@
+package kakao.rebit.feed.dto.request.update;
+
+public class UpdateFavoriteBookRequest extends UpdateFeedRequest {
+
+    private String briefReview;
+
+    private String fullReview;
+
+    private UpdateFavoriteBookRequest() {
+    }
+
+    public UpdateFavoriteBookRequest(Long bookId, String briefReview, String fullReview) {
+        super(bookId);
+        this.briefReview = briefReview;
+        this.fullReview = fullReview;
+    }
+
+    public String getBriefReview() {
+        return briefReview;
+    }
+
+    public String getFullReview() {
+        return fullReview;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/dto/request/update/UpdateFeedRequest.java
+++ b/src/main/java/kakao/rebit/feed/dto/request/update/UpdateFeedRequest.java
@@ -1,0 +1,30 @@
+package kakao.rebit.feed.dto.request.update;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type"
+)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = UpdateFavoriteBookRequest.class, name = "FB"),
+        @JsonSubTypes.Type(value = UpdateMagazineRequest.class, name = "M"),
+        @JsonSubTypes.Type(value = UpdateStoryRequest.class, name = "S")
+})
+public abstract class UpdateFeedRequest {
+
+    private Long bookId;
+
+    protected UpdateFeedRequest() {
+    }
+
+    public UpdateFeedRequest(Long bookId) {
+        this.bookId = bookId;
+    }
+
+    public Long getBookId() {
+        return bookId;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/dto/request/update/UpdateMagazineRequest.java
+++ b/src/main/java/kakao/rebit/feed/dto/request/update/UpdateMagazineRequest.java
@@ -1,0 +1,30 @@
+package kakao.rebit.feed.dto.request.update;
+
+public class UpdateMagazineRequest extends UpdateFeedRequest {
+
+    private String name;
+    private String imageUrl;
+    private String content;
+
+    private UpdateMagazineRequest() {
+    }
+
+    public UpdateMagazineRequest(Long bookId, String name, String imageUrl, String content) {
+        super(bookId);
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.content = content;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/dto/request/update/UpdateStoryRequest.java
+++ b/src/main/java/kakao/rebit/feed/dto/request/update/UpdateStoryRequest.java
@@ -1,0 +1,24 @@
+package kakao.rebit.feed.dto.request.update;
+
+public class UpdateStoryRequest extends UpdateFeedRequest {
+
+    private String imageUrl;
+    private String content;
+
+    private UpdateStoryRequest() {
+    }
+
+    public UpdateStoryRequest(Long bookId, String imageUrl, String content) {
+        super(bookId);
+        this.imageUrl = imageUrl;
+        this.content = content;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/kakao/rebit/feed/entity/FavoriteBook.java
+++ b/src/main/java/kakao/rebit/feed/entity/FavoriteBook.java
@@ -23,6 +23,19 @@ public class FavoriteBook extends Feed {
         this.fullReview = fullReview;
     }
 
+    @Override
+    public void updateNonNullFields(Feed feed) {
+        if (feed.getBook() != null) {
+            super.updateNonNullFields(feed);
+        }
+        if (((FavoriteBook) feed).getBriefReview() != null) {
+            this.briefReview = ((FavoriteBook) feed).getBriefReview();
+        }
+        if (((FavoriteBook) feed).getFullReview() != null) {
+            this.fullReview = ((FavoriteBook) feed).getFullReview();
+        }
+    }
+
     public String getBriefReview() {
         return briefReview;
     }

--- a/src/main/java/kakao/rebit/feed/entity/Feed.java
+++ b/src/main/java/kakao/rebit/feed/entity/Feed.java
@@ -51,6 +51,10 @@ public abstract class Feed extends BaseEntity {
         this.book = book;
     }
 
+    public void updateNonNullFields(Feed feed) {
+        this.book = feed.getBook();
+    }
+
     public Long getId() {
         return id;
     }
@@ -70,4 +74,5 @@ public abstract class Feed extends BaseEntity {
     public String getType() {
         return type;
     }
+
 }

--- a/src/main/java/kakao/rebit/feed/entity/Magazine.java
+++ b/src/main/java/kakao/rebit/feed/entity/Magazine.java
@@ -25,6 +25,22 @@ public class Magazine extends Feed {
         this.content = content;
     }
 
+    @Override
+    public void updateNonNullFields(Feed feed) {
+        if (feed.getBook() != null) {
+            super.updateNonNullFields(feed);
+        }
+        if (((Magazine) feed).getName() != null) {
+            this.name = ((Magazine) feed).getName();
+        }
+        if (((Magazine) feed).getImageUrl() != null) {
+            this.imageUrl = ((Magazine) feed).getImageUrl();
+        }
+        if (((Magazine) feed).getContent() != null) {
+            this.content = ((Magazine) feed).getContent();
+        }
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/kakao/rebit/feed/entity/Story.java
+++ b/src/main/java/kakao/rebit/feed/entity/Story.java
@@ -22,6 +22,19 @@ public class Story extends Feed {
         this.content = content;
     }
 
+    @Override
+    public void updateNonNullFields(Feed feed) {
+        if (feed.getBook() != null) {
+            super.updateNonNullFields(feed);
+        }
+        if (((Story) feed).getImageUrl() != null) {
+            this.imageUrl = ((Story) feed).getImageUrl();
+        }
+        if (((Story) feed).getContent() != null) {
+            this.content = ((Story) feed).getContent();
+        }
+    }
+
     public String getImageUrl() {
         return imageUrl;
     }

--- a/src/main/java/kakao/rebit/feed/mapper/FeedMapper.java
+++ b/src/main/java/kakao/rebit/feed/mapper/FeedMapper.java
@@ -1,0 +1,163 @@
+package kakao.rebit.feed.mapper;
+
+import kakao.rebit.book.entity.Book;
+import kakao.rebit.book.repository.BookRepository;
+import kakao.rebit.feed.dto.request.create.CreateFavoriteBookRequest;
+import kakao.rebit.feed.dto.request.create.CreateFeedRequest;
+import kakao.rebit.feed.dto.request.create.CreateMagazineRequest;
+import kakao.rebit.feed.dto.request.create.CreateStoryRequest;
+import kakao.rebit.feed.dto.request.update.UpdateFavoriteBookRequest;
+import kakao.rebit.feed.dto.request.update.UpdateFeedRequest;
+import kakao.rebit.feed.dto.request.update.UpdateMagazineRequest;
+import kakao.rebit.feed.dto.request.update.UpdateStoryRequest;
+import kakao.rebit.feed.dto.response.AuthorResponse;
+import kakao.rebit.feed.dto.response.BookResponse;
+import kakao.rebit.feed.dto.response.FavoriteBookResponse;
+import kakao.rebit.feed.dto.response.FeedResponse;
+import kakao.rebit.feed.dto.response.MagazineResponse;
+import kakao.rebit.feed.dto.response.StoryResponse;
+import kakao.rebit.feed.entity.FavoriteBook;
+import kakao.rebit.feed.entity.Feed;
+import kakao.rebit.feed.entity.Magazine;
+import kakao.rebit.feed.entity.Story;
+import kakao.rebit.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FeedMapper {
+
+    private final BookRepository bookRepository;
+
+    public FeedMapper(BookRepository bookRepository) {
+        this.bookRepository = bookRepository;
+    }
+
+    /**
+     * Entity -> DTO(Response) 변환
+     */
+
+    public AuthorResponse toAuthorResponse(Member member) {
+        return new AuthorResponse(member.getId(), member.getNickname(), member.getImageUrl());
+    }
+
+    public BookResponse toBookResponse(Book book) {
+        return new BookResponse(book.getId(), book.getIsbn(), book.getTitle(),
+                book.getDescription(), book.getAuthor(), book.getPublisher(), book.getImageUrl());
+    }
+
+    public FeedResponse toFeedResponse(Feed feed) {
+        if (feed instanceof FavoriteBook) {
+            return new FavoriteBookResponse(feed.getId(), toAuthorResponse(feed.getMember()),
+                    toBookResponse(feed.getBook()), feed.getType(),
+                    ((FavoriteBook) feed).getBriefReview(), ((FavoriteBook) feed).getFullReview());
+        }
+        if (feed instanceof Magazine) {
+            return new MagazineResponse(feed.getId(), toAuthorResponse(feed.getMember()),
+                    toBookResponse(feed.getBook()), feed.getType(),
+                    ((Magazine) feed).getName(), ((Magazine) feed).getImageUrl(),
+                    ((Magazine) feed).getContent());
+        }
+        if (feed instanceof Story) {
+            return new StoryResponse(feed.getId(), toAuthorResponse(feed.getMember()),
+                    toBookResponse(feed.getBook()), feed.getType(),
+                    ((Story) feed).getImageUrl(), ((Story) feed).getContent());
+        }
+        throw new IllegalStateException("유효하지 않는 피드입니다.");
+    }
+
+    public FavoriteBookResponse toFavoriteBookResponse(FavoriteBook favoriteBook) {
+        return new FavoriteBookResponse(favoriteBook.getId(),
+                this.toAuthorResponse(favoriteBook.getMember()),
+                this.toBookResponse(favoriteBook.getBook()),
+                favoriteBook.getType(), favoriteBook.getBriefReview(),
+                favoriteBook.getFullReview());
+    }
+
+    public MagazineResponse toMagazineResponse(Magazine magazine) {
+        return new MagazineResponse(
+                magazine.getId(),
+                this.toAuthorResponse(magazine.getMember()),
+                this.toBookResponse(magazine.getBook()),
+                magazine.getType(),
+                magazine.getName(),
+                magazine.getImageUrl(),
+                magazine.getContent()
+        );
+    }
+
+    public StoryResponse toStoryResponse(Story story) {
+        return new StoryResponse(
+                story.getId(),
+                this.toAuthorResponse(story.getMember()),
+                this.toBookResponse(story.getBook()),
+                story.getType(),
+                story.getImageUrl(),
+                story.getContent()
+        );
+    }
+
+    /**
+     * DTO(Request) -> Entity 변환
+     */
+
+    /**
+     * CreateFeedRequest 하위 항목들의 타입을 체크하고 각각의 엔티티로 반환
+     */
+    public Feed toFeed(Member member, CreateFeedRequest feedRequest) {
+        // request에 bookId가 있을 경우만 book을 가져온다.
+        Book book = null;
+        if (feedRequest.getBookId() != null) {
+            book = bookRepository.findById(feedRequest.getBookId())
+                    .orElseThrow(() -> new IllegalArgumentException("해당 책이 존재하지 않습니다."));
+        }
+
+        // 각 하위 클래스 생성
+        if (feedRequest instanceof CreateFavoriteBookRequest) {
+            if (book == null) {
+                throw new IllegalStateException("인생책 필드는 반드시 책이 존재 해야됩니다.");
+            }
+            return new FavoriteBook(member, book,
+                    ((CreateFavoriteBookRequest) feedRequest).getBriefReview(),
+                    ((CreateFavoriteBookRequest) feedRequest).getFullReview());
+        }
+        if (feedRequest instanceof CreateMagazineRequest) {
+            return new Magazine(member, book, ((CreateMagazineRequest) feedRequest).getName(),
+                    ((CreateMagazineRequest) feedRequest).getImageUrl(),
+                    ((CreateMagazineRequest) feedRequest).getContent());
+        }
+        if (feedRequest instanceof CreateStoryRequest) {
+            return new Story(member, book, ((CreateStoryRequest) feedRequest).getImageUrl(),
+                    ((CreateStoryRequest) feedRequest).getContent());
+        }
+        throw new IllegalStateException("유효하지 않는 피드 요청입니다.");
+    }
+
+    /**
+     * UpdateFeedRequest 하위 항목들의 타입을 체크하고 각각의 엔티티로 반환
+     */
+    public Feed toFeed(Member member, UpdateFeedRequest feedRequest) {
+        // request에 bookId가 있을 경우만 book을 가져온다.
+        Book book = null;
+        if (feedRequest.getBookId() != null) {
+            book = bookRepository.findById(feedRequest.getBookId())
+                    .orElseThrow(() -> new IllegalArgumentException("해당 책이 존재하지 않습니다."));
+        }
+
+        // 각 하위 클래스 생성
+        if (feedRequest instanceof UpdateFavoriteBookRequest) {
+            return new FavoriteBook(member, book,
+                    ((UpdateFavoriteBookRequest) feedRequest).getBriefReview(),
+                    ((UpdateFavoriteBookRequest) feedRequest).getFullReview());
+        }
+        if (feedRequest instanceof UpdateMagazineRequest) {
+            return new Magazine(member, book, ((UpdateMagazineRequest) feedRequest).getName(),
+                    ((UpdateMagazineRequest) feedRequest).getImageUrl(),
+                    ((UpdateMagazineRequest) feedRequest).getContent());
+        }
+        if (feedRequest instanceof UpdateStoryRequest) {
+            return new Story(member, book, ((UpdateStoryRequest) feedRequest).getImageUrl(),
+                    ((UpdateStoryRequest) feedRequest).getContent());
+        }
+        throw new IllegalStateException("유효하지 않는 피드 요청입니다.");
+    }
+}

--- a/src/main/java/kakao/rebit/feed/repository/FeedRepository.java
+++ b/src/main/java/kakao/rebit/feed/repository/FeedRepository.java
@@ -1,8 +1,11 @@
 package kakao.rebit.feed.repository;
 
+import java.util.Optional;
 import kakao.rebit.feed.entity.Feed;
+import kakao.rebit.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 
+    Optional<Feed> findByIdAndMember(Long feedId, Member member);
 }

--- a/src/main/java/kakao/rebit/feed/service/FavoriteBookService.java
+++ b/src/main/java/kakao/rebit/feed/service/FavoriteBookService.java
@@ -2,6 +2,7 @@ package kakao.rebit.feed.service;
 
 import kakao.rebit.feed.dto.response.FavoriteBookResponse;
 import kakao.rebit.feed.entity.FavoriteBook;
+import kakao.rebit.feed.mapper.FeedMapper;
 import kakao.rebit.feed.repository.FavoriteBookRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,37 +13,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class FavoriteBookService {
 
     private final FavoriteBookRepository favoriteBookRepository;
-    private final FeedService feedService;
+    private final FeedMapper feedMapper;
 
     public FavoriteBookService(FavoriteBookRepository favoriteBookRepository,
-            FeedService feedService) {
+            FeedMapper feedMapper) {
         this.favoriteBookRepository = favoriteBookRepository;
-        this.feedService = feedService;
+        this.feedMapper = feedMapper;
     }
 
     @Transactional(readOnly = true)
     public Page<FavoriteBookResponse> getFavoriteBooks(Pageable pageable) {
         Page<FavoriteBook> favorites = favoriteBookRepository.findAll(pageable);
         System.out.println(favorites);
-        return favorites.map(this::toFavoriteBookResponse);
+        return favorites.map(feedMapper::toFavoriteBookResponse);
     }
 
     @Transactional(readOnly = true)
     public FavoriteBookResponse getFavoriteBookById(Long id) {
         FavoriteBook favoriteBook = favoriteBookRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("찾는 인생책이 없습니다."));
-        return toFavoriteBookResponse(favoriteBook);
-    }
-
-    /**
-     * 아래부터는 DTO 변환 로직
-     */
-
-    private FavoriteBookResponse toFavoriteBookResponse(FavoriteBook favoriteBook) {
-        return new FavoriteBookResponse(favoriteBook.getId(),
-                feedService.toAuthorResponse(favoriteBook.getMember()),
-                feedService.toBookResponse(favoriteBook.getBook()),
-                favoriteBook.getType(), favoriteBook.getBriefReview(),
-                favoriteBook.getFullReview());
+        return feedMapper.toFavoriteBookResponse(favoriteBook);
     }
 }

--- a/src/main/java/kakao/rebit/feed/service/FeedService.java
+++ b/src/main/java/kakao/rebit/feed/service/FeedService.java
@@ -1,18 +1,14 @@
 package kakao.rebit.feed.service;
 
-import kakao.rebit.book.entity.Book;
-import kakao.rebit.feed.dto.response.AuthorResponse;
-import kakao.rebit.feed.dto.response.BookResponse;
-import kakao.rebit.feed.dto.response.FavoriteBookResponse;
+import kakao.rebit.feed.dto.request.create.CreateFeedRequest;
+import kakao.rebit.feed.dto.request.update.UpdateFeedRequest;
 import kakao.rebit.feed.dto.response.FeedResponse;
-import kakao.rebit.feed.dto.response.MagazineResponse;
-import kakao.rebit.feed.dto.response.StoryResponse;
-import kakao.rebit.feed.entity.FavoriteBook;
 import kakao.rebit.feed.entity.Feed;
-import kakao.rebit.feed.entity.Magazine;
-import kakao.rebit.feed.entity.Story;
+import kakao.rebit.feed.mapper.FeedMapper;
 import kakao.rebit.feed.repository.FeedRepository;
+import kakao.rebit.member.dto.MemberResponse;
 import kakao.rebit.member.entity.Member;
+import kakao.rebit.member.service.MemberService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -22,47 +18,49 @@ import org.springframework.transaction.annotation.Transactional;
 public class FeedService {
 
     private final FeedRepository feedRepository;
+    private final MemberService memberService;
 
-    public FeedService(FeedRepository feedRepository) {
+    private final FeedMapper feedMapper;
+
+    public FeedService(FeedRepository feedRepository, MemberService memberService,
+            FeedMapper feedMapper) {
         this.feedRepository = feedRepository;
+        this.memberService = memberService;
+        this.feedMapper = feedMapper;
     }
 
     @Transactional(readOnly = true)
     public Page<FeedResponse> getFeeds(Pageable pageable) {
-        return feedRepository.findAll(pageable).map(this::toFeedResponse);
+        return feedRepository.findAll(pageable).map(feedMapper::toFeedResponse);
     }
 
-    /**
-     * 아래부터는 DTO 변환 로직
-     */
-
-    private FeedResponse toFeedResponse(Feed feed) {
-        if (feed instanceof FavoriteBook) {
-            return new FavoriteBookResponse(feed.getId(), toAuthorResponse(feed.getMember()),
-                    toBookResponse(feed.getBook()), feed.getType(),
-                    ((FavoriteBook) feed).getBriefReview(), ((FavoriteBook) feed).getFullReview());
-        }
-        if (feed instanceof Magazine) {
-            return new MagazineResponse(feed.getId(), toAuthorResponse(feed.getMember()),
-                    toBookResponse(feed.getBook()), feed.getType(),
-                    ((Magazine) feed).getName(), ((Magazine) feed).getImageUrl(),
-                    ((Magazine) feed).getContent());
-        }
-        if (feed instanceof Story) {
-            return new StoryResponse(feed.getId(), toAuthorResponse(feed.getMember()),
-                    toBookResponse(feed.getBook()), feed.getType(),
-                    ((Story) feed).getImageUrl(), ((Story) feed).getContent());
-        }
-        throw new IllegalStateException("유효하지 않는 피드입니다.");
+    @Transactional(readOnly = true)
+    public FeedResponse getFeedById(Long feedId) {
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new IllegalArgumentException("찾는 피드가 존재하지 않습니다."));
+        return feedMapper.toFeedResponse(feed);
     }
 
-
-    public AuthorResponse toAuthorResponse(Member member) {
-        return new AuthorResponse(member.getId(), member.getNickname(), member.getImageUrl());
+    @Transactional
+    public Long createFeed(MemberResponse memberResponse, CreateFeedRequest feedRequest) {
+        Member member = memberService.findMemberByIdOrThrow(memberResponse.id());
+        Feed feed = feedMapper.toFeed(member, feedRequest);
+        return feedRepository.save(feed).getId();
     }
 
-    public BookResponse toBookResponse(Book book) {
-        return new BookResponse(book.getId(), book.getIsbn(), book.getTitle(),
-                book.getDescription(), book.getAuthor(), book.getPublisher(), book.getImageUrl());
+    @Transactional
+    public void updateFeed(MemberResponse memberResponse, Long feedId,
+            UpdateFeedRequest feedRequest) {
+        Member member = memberService.findMemberByIdOrThrow(memberResponse.id());
+        Feed feed = feedRepository.findByIdAndMember(feedId, member)
+                .orElseThrow(() -> new IllegalArgumentException("찾는 피드가 없습니다."));
+
+        Feed updateFeed = feedMapper.toFeed(member, feedRequest);
+        feed.updateNonNullFields(updateFeed);
+    }
+
+    @Transactional
+    public void deleteFeedById(Long feedId) {
+        feedRepository.deleteById(feedId);
     }
 }

--- a/src/main/java/kakao/rebit/feed/service/MagazineService.java
+++ b/src/main/java/kakao/rebit/feed/service/MagazineService.java
@@ -2,6 +2,7 @@ package kakao.rebit.feed.service;
 
 import kakao.rebit.feed.dto.response.MagazineResponse;
 import kakao.rebit.feed.entity.Magazine;
+import kakao.rebit.feed.mapper.FeedMapper;
 import kakao.rebit.feed.repository.MagazineRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,34 +13,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class MagazineService {
 
     private final MagazineRepository magazineRepository;
-    private final FeedService feedService;
+    private final FeedMapper feedMapper;
 
-    public MagazineService(MagazineRepository magazineRepository, FeedService feedService) {
+    public MagazineService(MagazineRepository magazineRepository, FeedMapper feedMapper) {
         this.magazineRepository = magazineRepository;
-        this.feedService = feedService;
+        this.feedMapper = feedMapper;
     }
 
     @Transactional(readOnly = true)
     public Page<MagazineResponse> getMagazines(Pageable pageable) {
-        return magazineRepository.findAll(pageable).map(this::toMagazineResponse);
+        return magazineRepository.findAll(pageable).map(feedMapper::toMagazineResponse);
     }
 
     @Transactional(readOnly = true)
     public MagazineResponse getMagazineById(Long id) {
         Magazine magazine = magazineRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("찾는 Magazine이 없습니다."));
-        return toMagazineResponse(magazine);
-    }
-
-    private MagazineResponse toMagazineResponse(Magazine magazine) {
-        return new MagazineResponse(
-                magazine.getId(),
-                feedService.toAuthorResponse(magazine.getMember()),
-                feedService.toBookResponse(magazine.getBook()),
-                magazine.getType(),
-                magazine.getName(),
-                magazine.getImageUrl(),
-                magazine.getContent()
-        );
+                .orElseThrow(() -> new IllegalArgumentException("찾는 메거진이 없습니다."));
+        return feedMapper.toMagazineResponse(magazine);
     }
 }

--- a/src/main/java/kakao/rebit/feed/service/StoryService.java
+++ b/src/main/java/kakao/rebit/feed/service/StoryService.java
@@ -2,6 +2,7 @@ package kakao.rebit.feed.service;
 
 import kakao.rebit.feed.dto.response.StoryResponse;
 import kakao.rebit.feed.entity.Story;
+import kakao.rebit.feed.mapper.FeedMapper;
 import kakao.rebit.feed.repository.StoryRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,37 +13,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class StoryService {
 
     private final StoryRepository storyRepository;
-    private final FeedService feedService;
+    private final FeedMapper feedMapper;
 
-    public StoryService(StoryRepository storyRepository, FeedService feedService) {
+    public StoryService(StoryRepository storyRepository, FeedMapper feedMapper) {
         this.storyRepository = storyRepository;
-        this.feedService = feedService;
+        this.feedMapper = feedMapper;
     }
 
     @Transactional(readOnly = true)
     public Page<StoryResponse> getStories(Pageable pageable) {
-        return storyRepository.findAll(pageable).map(this::toStoryResponse);
+        return storyRepository.findAll(pageable).map(feedMapper::toStoryResponse);
     }
 
     @Transactional(readOnly = true)
     public StoryResponse getStoryById(Long id) {
         Story story = storyRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("찾는 스토리가 없습니다."));
-        return toStoryResponse(story);
-    }
-
-    /**
-     * 아래부터는 DTO 변환 로직
-     */
-
-    private StoryResponse toStoryResponse(Story story) {
-        return new StoryResponse(
-                story.getId(),
-                feedService.toAuthorResponse(story.getMember()),
-                feedService.toBookResponse(story.getBook()),
-                story.getType(),
-                story.getImageUrl(),
-                story.getContent()
-        );
+        return feedMapper.toStoryResponse(story);
     }
 }


### PR DESCRIPTION
## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용 및 변경 사항
- 피드 생성, 수정, 삭제 구현
- 변환을 위한 Mapper 클래스 생성
- `KakaoAuthController`의 `@RequestParam` 쿼리 파라미터 이름 명시

## 이슈 링크
close #25 

## 참고 사항
![image](https://github.com/user-attachments/assets/13d88771-f2fc-4821-b662-46c0b406b322)
피드 생성 시, JSON 값으로 `"type": 피드 종류(FB, M, S)` 를 넘겨줘야 된다.

![image](https://github.com/user-attachments/assets/e348f907-8795-4c5c-926e-63558f9ca894)
수정 또한 마찬가지로 `"type": 피드 종류(FB, M, S)` 를 넘겨줘야 된다.

수정에 대해서 많이 고민했습니다. 
1. 지금 코드처럼 Dto를 다형성을 살려서 상속 구조로 설계한 뒤 UpdateXXXRequest를 각 Feed로 변환 시켜 도메인의 `updateNonNullFields()`에 넘겨서 오버라이딩을 통해 각각의 도메인에서 Null이 아닌 값들만 수정되도록 한다.

장점
- 엔드포인트가 `"/api/feeds/{feed-id}"` 하나로 통일된다.
- 서비스도 하나로 통일된다.
- 코드 중복이 사라지고 짧아진다.

단점
- `@Requestbody`로 받은 Dto 데이터를 검증할 때, bookId 필드는 인생책에서는 필수지만 메거진, 스토리에서는 필수가 아니기 때문에 Dto에서 바로 검증을 할 수 없다. 따로 service에서 인생책만 따로 검증을 해야 된다.
- Dto-Entity 간의 변환 코드가 많아진다.
- update 할 때는 객체를 전부 넘겨주는 것 보다 수정하고자 하는 필드 값을 넘겨주는 게 좋다고 배웠는데 다형성을 살리려면 부모 객체를 넘겨줘야 된다. 

2. 그냥 엔드포인트를 따로 작성해서 타입마다 각각 Dto와 Service를 만들고 Update 함수에 필드 값을 직접 넣어서 수정한다. 

장점
- 검증을 각 피드 특성에 맞게 세밀하게 할 수 있음
- 수정하고 하는 필드 값만 넘겨줘서 수정할 수 있다.

단점
- 중복 코드가 많아짐
- 코드가 길어짐
- 상속 관계의 이점을 잘 사용하지 못함

제가 잘못 생각하고 있거나 더 괜찮다고 생각하는 방법이 있으면 많은 피드백 부탁드립니다.. 

