### PR TITLE
[FEAT] 챌린지 인증글 조회, 생성, 삭제 구현

### DIFF
--- a/src/main/java/kakao/rebit/challenge/controller/ChallengeController.java
+++ b/src/main/java/kakao/rebit/challenge/controller/ChallengeController.java
@@ -51,7 +51,8 @@ public class ChallengeController {
 
     @DeleteMapping("/{challenge-id}")
     public ResponseEntity<Void> deleteChallenge(@PathVariable("challenge-id") Long challengeId) {
-        challengeService.deleteChallengeById(challengeId);
+        MemberResponse memberResponse = new MemberResponse(1L, "testUser", "imageUrl", "bio", Role.ROLE_USER, 10000);
+        challengeService.deleteChallengeById(memberResponse, challengeId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/kakao/rebit/challenge/controller/ChallengeVerificationController.java
+++ b/src/main/java/kakao/rebit/challenge/controller/ChallengeVerificationController.java
@@ -1,0 +1,64 @@
+package kakao.rebit.challenge.controller;
+
+import java.net.URI;
+import kakao.rebit.challenge.dto.ChallengeVerificationRequest;
+import kakao.rebit.challenge.dto.ChallengeVerificationResponse;
+import kakao.rebit.challenge.service.ChallengeVerificationService;
+import kakao.rebit.member.dto.MemberResponse;
+import kakao.rebit.member.entity.Role;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/challenges/{challenge-id}/verifications")
+public class ChallengeVerificationController {
+
+    private final ChallengeVerificationService challengeVerificationService;
+
+    public ChallengeVerificationController(ChallengeVerificationService challengeVerificationService) {
+        this.challengeVerificationService = challengeVerificationService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<ChallengeVerificationResponse>> getChallengeVerifications(
+            @PathVariable("challenge-id") Long challengeId,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok().body(challengeVerificationService.getChallengeVerificationsById(challengeId, pageable));
+    }
+
+    @GetMapping("/{verification-id}")
+    public ResponseEntity<ChallengeVerificationResponse> getChallengeVerification(
+            @PathVariable("challenge-id") Long challengeId,
+            @PathVariable("verification-id") Long verificationId) {
+        return ResponseEntity.ok().body(challengeVerificationService.getChallengeVerificationById(challengeId, verificationId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createChallengeVerification(
+            @PathVariable("challenge-id") Long challengeId,
+            @RequestBody ChallengeVerificationRequest challengeVerificationRequest) {
+        MemberResponse memberResponse = new MemberResponse(1L, "testUser", "imageUrl", "bio", Role.ROLE_USER, 10000);
+        Long verificationId = challengeVerificationService.createChallengeVerification(memberResponse, challengeId,
+                challengeVerificationRequest);
+        return ResponseEntity.created(URI.create("/challenges/" + challengeId + "/verifications/" + verificationId)).build();
+    }
+
+    @DeleteMapping("/{verification-id}")
+    public ResponseEntity<Void> deleteChallengeVerification(
+            @PathVariable("challenge-id") Long challengeId,
+            @PathVariable("verification-id") Long verificationId) {
+        MemberResponse memberResponse = new MemberResponse(1L, "testUser", "imageUrl", "bio", Role.ROLE_USER, 10000);
+        challengeVerificationService.deleteChallengeVerification(memberResponse, challengeId, verificationId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/kakao/rebit/challenge/dto/AuthorResponse.java
+++ b/src/main/java/kakao/rebit/challenge/dto/AuthorResponse.java
@@ -1,0 +1,9 @@
+package kakao.rebit.challenge.dto;
+
+public record AuthorResponse(
+        Long id,
+        String nickname,
+        String imageUrl
+) {
+
+}

--- a/src/main/java/kakao/rebit/challenge/dto/ChallengeVerificationRequest.java
+++ b/src/main/java/kakao/rebit/challenge/dto/ChallengeVerificationRequest.java
@@ -1,0 +1,9 @@
+package kakao.rebit.challenge.dto;
+
+public record ChallengeVerificationRequest(
+        String title,
+        String imageUrl,
+        String content
+) {
+
+}

--- a/src/main/java/kakao/rebit/challenge/dto/ChallengeVerificationResponse.java
+++ b/src/main/java/kakao/rebit/challenge/dto/ChallengeVerificationResponse.java
@@ -1,0 +1,15 @@
+package kakao.rebit.challenge.dto;
+
+import java.time.LocalDateTime;
+
+public record ChallengeVerificationResponse(
+        Long id,
+        Long participationId,
+        AuthorResponse author,
+        String title,
+        String imageUrl,
+        String content,
+        LocalDateTime createdAt
+) {
+
+}

--- a/src/main/java/kakao/rebit/challenge/entity/Challenge.java
+++ b/src/main/java/kakao/rebit/challenge/entity/Challenge.java
@@ -125,15 +125,23 @@ public class Challenge extends BaseEntity {
         return currentHeadcount;
     }
 
+    public boolean isHostedBy(Member member) {
+        return this.member.equals(member);
+    }
+
     public boolean isRecruiting(LocalDateTime now) {
         return recruitmentPeriod.contains(now);
     }
 
-    public boolean isInProgress(LocalDateTime now) {
+    public boolean canBeDeleted(LocalDateTime now) {
+        return !isOngoing(now) && !isCompleted(now);
+    }
+
+    private boolean isOngoing(LocalDateTime now) {
         return challengePeriod.contains(now);
     }
 
-    public boolean isCompleted(LocalDateTime now) {
+    private boolean isCompleted(LocalDateTime now) {
         return challengePeriod.isAfter(now);
     }
 

--- a/src/main/java/kakao/rebit/challenge/entity/Challenge.java
+++ b/src/main/java/kakao/rebit/challenge/entity/Challenge.java
@@ -137,7 +137,7 @@ public class Challenge extends BaseEntity {
         return !isOngoing(now) && !isCompleted(now);
     }
 
-    private boolean isOngoing(LocalDateTime now) {
+    public boolean isOngoing(LocalDateTime now) {
         return challengePeriod.contains(now);
     }
 

--- a/src/main/java/kakao/rebit/challenge/entity/Challenge.java
+++ b/src/main/java/kakao/rebit/challenge/entity/Challenge.java
@@ -145,7 +145,7 @@ public class Challenge extends BaseEntity {
         return challengePeriod.isAfter(now);
     }
 
-    public boolean isWithinHeadcountLimit(int currentHeadcount) {
-        return headcountLimit.isWithinLimit(currentHeadcount);
+    public boolean isFull() {
+        return headcountLimit.isFull(currentHeadcount);
     }
 }

--- a/src/main/java/kakao/rebit/challenge/entity/ChallengeVerification.java
+++ b/src/main/java/kakao/rebit/challenge/entity/ChallengeVerification.java
@@ -9,11 +9,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kakao.rebit.common.persistence.BaseEntity;
-import kakao.rebit.member.entity.Member;
 
 @Entity
-@Table(name = "challenge_certification")
-public class ChallengeCertification extends BaseEntity {
+@Table(name = "challenge_verification")
+public class ChallengeVerification extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,23 +25,17 @@ public class ChallengeCertification extends BaseEntity {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "challenge_id")
-    private Challenge challenge;
+    @JoinColumn(name = "challenge_participation_id")
+    private ChallengeParticipation challengeParticipation;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    protected ChallengeCertification() {
+    protected ChallengeVerification() {
     }
 
-    public ChallengeCertification(String title, String imageUrl, String content,
-        Challenge challenge, Member member) {
+    public ChallengeVerification(String title, String imageUrl, String content, ChallengeParticipation challengeParticipation) {
         this.title = title;
         this.imageUrl = imageUrl;
         this.content = content;
-        this.challenge = challenge;
-        this.member = member;
+        this.challengeParticipation = challengeParticipation;
     }
 
     public Long getId() {
@@ -61,11 +54,7 @@ public class ChallengeCertification extends BaseEntity {
         return content;
     }
 
-    public Challenge getChallenge() {
-        return challenge;
-    }
-
-    public Member getMember() {
-        return member;
+    public ChallengeParticipation getChallengeParticipation() {
+        return challengeParticipation;
     }
 }

--- a/src/main/java/kakao/rebit/challenge/entity/HeadcountLimit.java
+++ b/src/main/java/kakao/rebit/challenge/entity/HeadcountLimit.java
@@ -26,8 +26,8 @@ public class HeadcountLimit {
         return maxHeadcount;
     }
 
-    public boolean isWithinLimit(int currentHeadcount) {
-        return currentHeadcount >= minHeadcount && currentHeadcount <= maxHeadcount;
+    public boolean isFull(int currentHeadcount) {
+        return currentHeadcount >= maxHeadcount;
     }
 
     @Override

--- a/src/main/java/kakao/rebit/challenge/repository/ChallengeCertificationRepository.java
+++ b/src/main/java/kakao/rebit/challenge/repository/ChallengeCertificationRepository.java
@@ -1,8 +1,0 @@
-package kakao.rebit.challenge.repository;
-
-import kakao.rebit.challenge.entity.ChallengeCertification;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ChallengeCertificationRepository extends JpaRepository<ChallengeCertification, Long> {
-
-}

--- a/src/main/java/kakao/rebit/challenge/repository/ChallengeParticipationRepository.java
+++ b/src/main/java/kakao/rebit/challenge/repository/ChallengeParticipationRepository.java
@@ -1,18 +1,24 @@
 package kakao.rebit.challenge.repository;
 
+import java.util.Optional;
 import kakao.rebit.challenge.entity.Challenge;
 import kakao.rebit.challenge.entity.ChallengeParticipation;
 import kakao.rebit.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ChallengeParticipationRepository extends JpaRepository<ChallengeParticipation, Long> {
 
-    @Query("SELECT cp FROM ChallengeParticipation cp JOIN FETCH cp.member WHERE cp.challenge = :challenge")
+    @EntityGraph(attributePaths = {"member"})
+    @Query("SELECT cp FROM ChallengeParticipation cp WHERE cp.challenge = :challenge")
     Page<ChallengeParticipation> findAllByChallengeWithMember(@Param("challenge") Challenge challenge, Pageable pageable);
 
     Boolean existsByMemberAndChallenge(Member member, Challenge challenge);
+
+    @EntityGraph(attributePaths = {"member", "challenge"})
+    Optional<ChallengeParticipation> findByMemberAndChallenge(Member member, Challenge challenge);
 }

--- a/src/main/java/kakao/rebit/challenge/repository/ChallengeVerificationRepository.java
+++ b/src/main/java/kakao/rebit/challenge/repository/ChallengeVerificationRepository.java
@@ -16,6 +16,6 @@ public interface ChallengeVerificationRepository extends JpaRepository<Challenge
     @Query("SELECT cv FROM ChallengeVerification cv WHERE cv.challengeParticipation.challenge = :challenge")
     Page<ChallengeVerification> findAllByChallengeWithParticipants(@Param("challenge") Challenge challenge, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"challengeParticipation", "challengeParticipation.member", "challengeParticipation.challenge"})
+    @EntityGraph(attributePaths = {"challengeParticipation", "challengeParticipation.member"})
     Optional<ChallengeVerification> findByIdAndChallengeParticipation_Challenge(Long verificationId, Challenge challenge);
 }

--- a/src/main/java/kakao/rebit/challenge/repository/ChallengeVerificationRepository.java
+++ b/src/main/java/kakao/rebit/challenge/repository/ChallengeVerificationRepository.java
@@ -1,8 +1,21 @@
 package kakao.rebit.challenge.repository;
 
+import java.util.Optional;
+import kakao.rebit.challenge.entity.Challenge;
 import kakao.rebit.challenge.entity.ChallengeVerification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChallengeVerificationRepository extends JpaRepository<ChallengeVerification, Long> {
 
+    @EntityGraph(attributePaths = {"challengeParticipation", "challengeParticipation.member", "challengeParticipation.challenge"})
+    @Query("SELECT cv FROM ChallengeVerification cv WHERE cv.challengeParticipation.challenge = :challenge")
+    Page<ChallengeVerification> findAllByChallengeWithParticipants(@Param("challenge") Challenge challenge, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"challengeParticipation", "challengeParticipation.member", "challengeParticipation.challenge"})
+    Optional<ChallengeVerification> findByIdAndChallengeParticipation_Challenge(Long verificationId, Challenge challenge);
 }

--- a/src/main/java/kakao/rebit/challenge/repository/ChallengeVerificationRepository.java
+++ b/src/main/java/kakao/rebit/challenge/repository/ChallengeVerificationRepository.java
@@ -1,0 +1,8 @@
+package kakao.rebit.challenge.repository;
+
+import kakao.rebit.challenge.entity.ChallengeVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChallengeVerificationRepository extends JpaRepository<ChallengeVerification, Long> {
+
+}

--- a/src/main/java/kakao/rebit/challenge/service/ChallengeParticipationService.java
+++ b/src/main/java/kakao/rebit/challenge/service/ChallengeParticipationService.java
@@ -46,6 +46,12 @@ public class ChallengeParticipationService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 참여 정보입니다."));
     }
 
+    @Transactional(readOnly = true)
+    public ChallengeParticipation findChallengeParticipationByMemberAndChallengeOrThrow(Member member, Challenge challenge) {
+        return challengeParticipationRepository.findByMemberAndChallenge(member, challenge)
+                .orElseThrow(() -> new IllegalArgumentException("참여 정보가 존재하지 않습니다."));
+    }
+
     @Transactional
     public Long createChallengeParticipation(MemberResponse memberResponse, Long challengeId, ChallengeParticipationRequest challengeParticipationRequest) {
         Member member = memberService.findMemberByIdOrThrow(memberResponse.id());

--- a/src/main/java/kakao/rebit/challenge/service/ChallengeParticipationService.java
+++ b/src/main/java/kakao/rebit/challenge/service/ChallengeParticipationService.java
@@ -67,6 +67,10 @@ public class ChallengeParticipationService {
             throw new IllegalArgumentException("모집 기간이 아닙니다.");
         }
 
+        if (challenge.isFull()) {
+            throw new IllegalArgumentException("모집 인원이 다 찼습니다.");
+        }
+
         if (entryFee > member.getPoint()) {
             throw new IllegalArgumentException("포인트가 부족합니다.");
         }

--- a/src/main/java/kakao/rebit/challenge/service/ChallengeParticipationService.java
+++ b/src/main/java/kakao/rebit/challenge/service/ChallengeParticipationService.java
@@ -55,18 +55,16 @@ public class ChallengeParticipationService {
         validateChallengeParticipation(member, challenge, entryFee);
 
         ChallengeParticipation challengeParticipation = toChallengeParticipation(member, challenge, entryFee);
-        challengeParticipationRepository.save(challengeParticipation);
-
-        return challengeParticipation.getId();
+        return challengeParticipationRepository.save(challengeParticipation).getId();
     }
 
     private void validateChallengeParticipation(Member member, Challenge challenge, Integer entryFee) {
-        if (!challenge.isRecruiting(LocalDateTime.now())) {
-            throw new IllegalArgumentException("모집 기간이 아닙니다.");
-        }
-
         if (challengeParticipationRepository.existsByMemberAndChallenge(member, challenge)) {
             throw new IllegalArgumentException("이미 참여한 챌린지입니다.");
+        }
+
+        if (!challenge.isRecruiting(LocalDateTime.now())) {
+            throw new IllegalArgumentException("모집 기간이 아닙니다.");
         }
 
         if (entryFee > member.getPoint()) {

--- a/src/main/java/kakao/rebit/challenge/service/ChallengeService.java
+++ b/src/main/java/kakao/rebit/challenge/service/ChallengeService.java
@@ -1,5 +1,6 @@
 package kakao.rebit.challenge.service;
 
+import java.time.LocalDateTime;
 import kakao.rebit.challenge.dto.ChallengeRequest;
 import kakao.rebit.challenge.dto.ChallengeResponse;
 import kakao.rebit.challenge.dto.CreatorResponse;
@@ -52,7 +53,18 @@ public class ChallengeService {
     }
 
     @Transactional
-    public void deleteChallengeById(Long challengeId) {
+    public void deleteChallengeById(MemberResponse memberResponse, Long challengeId) {
+        Member member = memberService.findMemberByIdOrThrow(memberResponse.id());
+        Challenge challenge = findChallengeByIdOrThrow(challengeId);
+
+        if (!challenge.isHostedBy(member)) {
+            throw new IllegalArgumentException("챌린지 주최자만 삭제할 수 있습니다.");
+        }
+
+        if (challenge.canBeDeleted(LocalDateTime.now())) {
+            throw new IllegalArgumentException("진행 중이거나 종료된 챌린지는 삭제할 수 없습니다.");
+        }
+
         challengeRepository.deleteById(challengeId);
     }
 

--- a/src/main/java/kakao/rebit/challenge/service/ChallengeVerificationService.java
+++ b/src/main/java/kakao/rebit/challenge/service/ChallengeVerificationService.java
@@ -1,0 +1,108 @@
+package kakao.rebit.challenge.service;
+
+import kakao.rebit.challenge.dto.AuthorResponse;
+import kakao.rebit.challenge.dto.ChallengeVerificationRequest;
+import kakao.rebit.challenge.dto.ChallengeVerificationResponse;
+import kakao.rebit.challenge.entity.Challenge;
+import kakao.rebit.challenge.entity.ChallengeParticipation;
+import kakao.rebit.challenge.entity.ChallengeVerification;
+import kakao.rebit.challenge.repository.ChallengeVerificationRepository;
+import kakao.rebit.member.dto.MemberResponse;
+import kakao.rebit.member.entity.Member;
+import kakao.rebit.member.service.MemberService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ChallengeVerificationService {
+
+    private final ChallengeService challengeService;
+    private final MemberService memberService;
+    private final ChallengeVerificationRepository challengeVerificationRepository;
+    private final ChallengeParticipationService challengeParticipationService;
+
+    public ChallengeVerificationService(ChallengeService challengeService, MemberService memberService,
+            ChallengeVerificationRepository challengeVerificationRepository, ChallengeParticipationService challengeParticipationService) {
+        this.challengeService = challengeService;
+        this.memberService = memberService;
+        this.challengeVerificationRepository = challengeVerificationRepository;
+        this.challengeParticipationService = challengeParticipationService;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ChallengeVerificationResponse> getChallengeVerificationsById(Long challengeId, Pageable pageable) {
+        Challenge challenge = challengeService.findChallengeByIdOrThrow(challengeId);
+        Page<ChallengeVerification> challengeVerifications = challengeVerificationRepository.findAllByChallengeWithParticipants(challenge, pageable);
+        return challengeVerifications.map(this::toChallengeVerificationResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public ChallengeVerificationResponse getChallengeVerificationById(Long challengeId, Long verificationId) {
+        Challenge challenge = challengeService.findChallengeByIdOrThrow(challengeId);
+        ChallengeVerification challengeVerification = findByIdAndChallengeOrThrow(verificationId, challenge);
+        return toChallengeVerificationResponse(challengeVerification);
+
+    }
+
+    private ChallengeVerification findByIdAndChallengeOrThrow(Long verificationId, Challenge challenge) {
+        return challengeVerificationRepository.findByIdAndChallengeParticipation_Challenge(verificationId,
+                        challenge)
+                .orElseThrow(() -> new IllegalArgumentException("찾는 인증글이 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public Long createChallengeVerification(MemberResponse memberResponse, Long challengeId,
+            ChallengeVerificationRequest challengeVerificationRequest) {
+        Member member = memberService.findMemberByIdOrThrow(memberResponse.id());
+        Challenge challenge = challengeService.findChallengeByIdOrThrow(challengeId);
+        ChallengeParticipation challengeParticipation = challengeParticipationService.findChallengeParticipationByMemberAndChallengeOrThrow(
+                member, challenge);
+
+        return challengeVerificationRepository.save(toChallengeVerification(challengeParticipation, challengeVerificationRequest)).getId();
+    }
+
+    @Transactional
+    public void deleteChallengeVerification(MemberResponse memberResponse, Long challengeId, Long verificationId) {
+        Member member = memberService.findMemberByIdOrThrow(memberResponse.id());
+        Challenge challenge = challengeService.findChallengeByIdOrThrow(challengeId);
+        ChallengeVerification challengeVerification = findByIdAndChallengeOrThrow(verificationId, challenge);
+
+        if (!challengeVerification.getChallengeParticipation().getMember().getId().equals(member.getId())) {
+            throw new IllegalArgumentException("본인이 올린 인증글만 삭제할 수 있습니다.");
+        }
+
+        challengeVerificationRepository.delete(challengeVerification);
+    }
+
+    private ChallengeVerificationResponse toChallengeVerificationResponse(ChallengeVerification challengeVerification) {
+        return new ChallengeVerificationResponse(
+                challengeVerification.getId(),
+                challengeVerification.getChallengeParticipation().getId(),
+                toAuthorResponse(challengeVerification.getChallengeParticipation().getMember()),
+                challengeVerification.getTitle(),
+                challengeVerification.getImageUrl(),
+                challengeVerification.getContent(),
+                challengeVerification.getCreatedAt()
+        );
+    }
+
+    private AuthorResponse toAuthorResponse(Member member) {
+        return new AuthorResponse(
+                member.getId(),
+                member.getNickname(),
+                member.getImageUrl()
+        );
+    }
+
+    private ChallengeVerification toChallengeVerification(ChallengeParticipation challengeParticipation,
+            ChallengeVerificationRequest challengeVerificationRequest) {
+        return new ChallengeVerification(
+                challengeVerificationRequest.title(),
+                challengeVerificationRequest.imageUrl(),
+                challengeVerificationRequest.content(),
+                challengeParticipation
+        );
+    }
+}

--- a/src/main/java/kakao/rebit/challenge/service/ChallengeVerificationService.java
+++ b/src/main/java/kakao/rebit/challenge/service/ChallengeVerificationService.java
@@ -1,5 +1,6 @@
 package kakao.rebit.challenge.service;
 
+import java.time.LocalDateTime;
 import kakao.rebit.challenge.dto.AuthorResponse;
 import kakao.rebit.challenge.dto.ChallengeVerificationRequest;
 import kakao.rebit.challenge.dto.ChallengeVerificationResponse;
@@ -57,6 +58,11 @@ public class ChallengeVerificationService {
             ChallengeVerificationRequest challengeVerificationRequest) {
         Member member = memberService.findMemberByIdOrThrow(memberResponse.id());
         Challenge challenge = challengeService.findChallengeByIdOrThrow(challengeId);
+
+        if (!challenge.isOngoing(LocalDateTime.now())) {
+            throw new IllegalArgumentException("챌린지가 진행 중에만 인증글을 작성할 수 있습니다.");
+        }
+
         ChallengeParticipation challengeParticipation = challengeParticipationService.findChallengeParticipationByMemberAndChallengeOrThrow(
                 member, challenge);
 


### PR DESCRIPTION
## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용 및 변경 사항
- 챌린지 인증글은 페이지네이션으로 구현
- 챌린지 인증글 생성, 삭제 구현

## 이슈 링크
close #38 

## 참고사항
- 챌린지 인증글은 챌린지를 참여한 사람들에 한해서 작성 가능해야 하므로 연관관계를 변경했습니다.
  기존에는 사용자, 챌린지 테이블에 대한 연관관계를 가지고 있었다면, 현재는 챌린지 참여 테이블에 대한 연관관계만 갖도록 변경했습니다.
