### PR TITLE
[FEAT] 인증 불필요한 엔드포인트에 적용하는 어노테이션 구현

### DIFF
--- a/src/main/java/kakao/rebit/auth/controller/KakaoAuthController.java
+++ b/src/main/java/kakao/rebit/auth/controller/KakaoAuthController.java
@@ -2,6 +2,7 @@ package kakao.rebit.auth.controller;
 
 import kakao.rebit.auth.dto.LoginResponse;
 import kakao.rebit.auth.service.KakaoAuthService;
+import kakao.rebit.common.annotation.AllowAnonymous;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -28,6 +29,7 @@ public class KakaoAuthController {
 
     // 테스트용 html
     // 로그인 버튼을 클릭하면 인가코드를 받아옵니다.
+    @AllowAnonymous
     @GetMapping("/login")
     public String showLoginForm(Model model) {
         model.addAttribute("clientId", clientId);
@@ -35,6 +37,7 @@ public class KakaoAuthController {
         return "loginForm";
     }
 
+    @AllowAnonymous
     @GetMapping("/login/oauth/kakao")
     @ResponseBody
     public LoginResponse kakaoLogin(@RequestParam("code") String code) {

--- a/src/main/java/kakao/rebit/auth/jwt/JwtInterceptor.java
+++ b/src/main/java/kakao/rebit/auth/jwt/JwtInterceptor.java
@@ -14,7 +14,7 @@ public class JwtInterceptor implements HandlerInterceptor {
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
 
-    private JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public JwtInterceptor(JwtTokenProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider;

--- a/src/main/java/kakao/rebit/auth/jwt/JwtInterceptor.java
+++ b/src/main/java/kakao/rebit/auth/jwt/JwtInterceptor.java
@@ -2,9 +2,10 @@ package kakao.rebit.auth.jwt;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
+import kakao.rebit.common.annotation.AllowAnonymous;
 import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
@@ -24,6 +25,11 @@ public class JwtInterceptor implements HandlerInterceptor {
 
         // CORS preflight 요청은 토큰 검증을 하지 않음
         if (CorsUtils.isPreFlightRequest(request)) {
+            return true;
+        }
+
+        // AllowAnonymous 어노테이션이 붙어있는 경우 토큰 검증을 하지 않음
+        if (handler instanceof HandlerMethod handlerMethod && handlerMethod.getMethodAnnotation(AllowAnonymous.class) != null) {
             return true;
         }
 

--- a/src/main/java/kakao/rebit/challenge/controller/ChallengeController.java
+++ b/src/main/java/kakao/rebit/challenge/controller/ChallengeController.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import kakao.rebit.challenge.dto.ChallengeRequest;
 import kakao.rebit.challenge.dto.ChallengeResponse;
 import kakao.rebit.challenge.service.ChallengeService;
+import kakao.rebit.common.annotation.AllowAnonymous;
 import kakao.rebit.member.annotation.MemberInfo;
 import kakao.rebit.member.dto.MemberResponse;
 import org.springframework.data.domain.Page;
@@ -35,6 +36,7 @@ public class ChallengeController {
     }
 
     @Operation(summary = "챌린지 목록 조회", description = "챌린지 목록을 조회합니다.")
+    @AllowAnonymous
     @GetMapping
     public ResponseEntity<Page<ChallengeResponse>> getChallenges(
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -42,6 +44,7 @@ public class ChallengeController {
     }
 
     @Operation(summary = "챌린지 조회", description = "챌린지를 조회합니다.")
+    @AllowAnonymous
     @GetMapping("/{challenge-id}")
     public ResponseEntity<ChallengeResponse> getChallenge(@PathVariable("challenge-id") Long challengeId) {
         return ResponseEntity.ok().body(challengeService.getChallengeById(challengeId));

--- a/src/main/java/kakao/rebit/challenge/controller/ChallengeParticipationController.java
+++ b/src/main/java/kakao/rebit/challenge/controller/ChallengeParticipationController.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import kakao.rebit.challenge.dto.ChallengeParticipationMemberResponse;
 import kakao.rebit.challenge.dto.ChallengeParticipationRequest;
 import kakao.rebit.challenge.service.ChallengeParticipationService;
+import kakao.rebit.common.annotation.AllowAnonymous;
 import kakao.rebit.member.annotation.MemberInfo;
 import kakao.rebit.member.dto.MemberResponse;
 import org.springframework.data.domain.Page;
@@ -35,6 +36,7 @@ public class ChallengeParticipationController {
     }
 
     @Operation(summary = "챌린지 참여자 목록 조회", description = "챌린지 참여자 목록을 조회합니다.")
+    @AllowAnonymous
     @GetMapping
     public ResponseEntity<Page<ChallengeParticipationMemberResponse>> getChallengeParticipations(
             @PathVariable("challenge-id") Long challengeId,
@@ -43,6 +45,7 @@ public class ChallengeParticipationController {
     }
 
     @Operation(summary = "챌린지 참여자 조회", description = "챌린지 참여자를 조회합니다.")
+    @AllowAnonymous
     @GetMapping("/{participation-id}")
     public ResponseEntity<ChallengeParticipationMemberResponse> getChallengeParticipation(
             @PathVariable("challenge-id") Long challengeId,    // challenge-id는 사용되지 않지만 URL 일관성을 위해 유지

--- a/src/main/java/kakao/rebit/challenge/controller/ChallengeVerificationController.java
+++ b/src/main/java/kakao/rebit/challenge/controller/ChallengeVerificationController.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import kakao.rebit.challenge.dto.ChallengeVerificationRequest;
 import kakao.rebit.challenge.dto.ChallengeVerificationResponse;
 import kakao.rebit.challenge.service.ChallengeVerificationService;
+import kakao.rebit.common.annotation.AllowAnonymous;
 import kakao.rebit.member.annotation.MemberInfo;
 import kakao.rebit.member.dto.MemberResponse;
 import org.springframework.data.domain.Page;
@@ -35,6 +36,7 @@ public class ChallengeVerificationController {
     }
 
     @Operation(summary = "챌린지 인증글 목록 조회", description = "챌린지 인증글 목록을 조회합니다.")
+    @AllowAnonymous
     @GetMapping
     public ResponseEntity<Page<ChallengeVerificationResponse>> getChallengeVerifications(
             @PathVariable("challenge-id") Long challengeId,
@@ -43,6 +45,7 @@ public class ChallengeVerificationController {
     }
 
     @Operation(summary = "챌린지 인증글 조회", description = "챌린지 인증글을 조회합니다.")
+    @AllowAnonymous
     @GetMapping("/{verification-id}")
     public ResponseEntity<ChallengeVerificationResponse> getChallengeVerification(
             @PathVariable("challenge-id") Long challengeId,

--- a/src/main/java/kakao/rebit/common/annotation/AllowAnonymous.java
+++ b/src/main/java/kakao/rebit/common/annotation/AllowAnonymous.java
@@ -1,0 +1,12 @@
+package kakao.rebit.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AllowAnonymous {
+
+}

--- a/src/main/java/kakao/rebit/common/config/WebConfig.java
+++ b/src/main/java/kakao/rebit/common/config/WebConfig.java
@@ -43,9 +43,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
-                .addPathPatterns("/api/**")
                 .excludePathPatterns(
-                        "/api/auth/**",
                         "/swagger-ui/**",
                         "/swagger-resources/**",
                         "/v3/api-docs/**"


### PR DESCRIPTION
## PR 유형
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용 및 변경 사항
인증이 필요하지 않은 요청들에 대해 인터셉터에서 인증을 거치지 않고 통과시킬 수 있도록 어노테이션 구현

## 이슈 링크
close #74 

## 참고사항
- 인증이 불필요한 곳에 `@AllowAnonymous` 어노테이션을 붙이면 됩니다.
- 어노테이션 위치는 `@Operation`과 `@~Mapping` 사이로 통일하면 좋을 것 같습니다.
- 챌린지 도메인 적용한 부분 참고해주세요